### PR TITLE
Remove prepublishOnly for Test package

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
+    "build": "echo 'No build needed for test package'",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
-    "prepublishOnly": "npm run clean && npm run build",
     "ci": "npm ci",
     "build:all": "npm run build --workspaces"
   },


### PR DESCRIPTION
Since package is set to private, prepublishOnly is unnecessary