### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     name: Node.js SDK
     needs: [changed-sdks]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Agent365-nodejs/security/code-scanning/2](https://github.com/microsoft/Agent365-nodejs/security/code-scanning/2)

To fix this issue, you should add an explicit `permissions` block with the minimal required privileges to the affected job (`nodejs-sdk`). Since the steps performed are read-only (building, testing, artifact upload) and do not modify repository contents or interact with issues/pull-requests, the `contents: read` permission is sufficient and safest. Edit the `.github/workflows/ci.yml` file, adding the following under the `nodejs-sdk` job definition (right after line 46, under `runs-on: ubuntu-latest`). No imports or further code changes are required—just this YAML configuration block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
