### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   changed-sdks:
     name: Determine Changed SDKs
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       nodejs-sdk: ${{ steps.check_nodejs_sdk.outputs.changed }}


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Agent365-nodejs/security/code-scanning/1](https://github.com/microsoft/Agent365-nodejs/security/code-scanning/1)

To fix the problem, explicitly set the permissions for the "changed-sdks" job to the minimum necessary, following the principle of least privilege. The best and minimal way is to add the following block under `changed-sdks:` at the same indentation as `name:`:
```yaml
permissions:
  contents: read
```
This will ensure that the GitHub Actions GITHUB_TOKEN used by this job only has read access to repository contents, and does not inherit broader permissions from the repository or organization default. No other code changes are required, and this does not affect the functionality of the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
