### PR TITLE
McpToolServerConfigurationService do not assume the env is development unless explicitly set

### DIFF
--- a/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
+++ b/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
@@ -157,7 +157,7 @@ export class McpToolServerConfigurationService {
    * @returns {boolean} True when running in a development environment.
    */
   private isDevScenario(): boolean {
-    const environment = process.env.NODE_ENV || 'Development';
+    const environment = process.env.NODE_ENV || '';
     return environment.toLowerCase() === 'development';
   }
 }


### PR DESCRIPTION
As an SDK to be used by other applications it's better to assume less and not force users to set environment variables to achieve what should be the default behavior (production) when it can be avoided.

This pull request makes a small change to the environment detection logic in the `McpToolServerConfigurationService` class. The default value for `NODE_ENV` is now set to an empty string instead of `'Development'`, making the development check more explicit and less assuming.

I could be convinced to fallback straight to 'production' for example. Similarly, we could also to expand the conditional on the line after that to check for other similar strings like 'dev' and 'local'. But this is the minimal change that achieves the desired behavior.