### PR TITLE
Add OTEL gen-ai message format for auto-instrumented message tracing

### DIFF
--- a/packages/agents-a365-observability-extensions-langchain/src/LangChainTraceInstrumentor.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/LangChainTraceInstrumentor.ts
@@ -20,9 +20,8 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
   private _hasBeenEnabled = false;
   private _isPatched = false;
   protected otelTracer: Tracer;
-  private isContentRecordingEnabled: boolean;
 
-  private constructor(options?: { isContentRecordingEnabled?: boolean }) {
+  private constructor() {
     if (LangChainTraceInstrumentorImpl._instance !== null) {
       throw new Error("LangChainTraceInstrumentor can only be instantiated once.");
     }
@@ -42,15 +41,14 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
       "agent365-langchain",
       "1.0.0"
     );
-    this.isContentRecordingEnabled = options?.isContentRecordingEnabled ?? false;
 
     LangChainTraceInstrumentorImpl._instance = this;
     logger.info("[LangChainTraceInstrumentor] Initialized and automatically enabled");
   }
 
-  static getInstance(options?: { isContentRecordingEnabled?: boolean }): LangChainTraceInstrumentorImpl {
+  static getInstance(): LangChainTraceInstrumentorImpl {
     if (!LangChainTraceInstrumentorImpl._instance) {
-      LangChainTraceInstrumentorImpl._instance = new LangChainTraceInstrumentorImpl(options);
+      LangChainTraceInstrumentorImpl._instance = new LangChainTraceInstrumentorImpl();
     }
     return LangChainTraceInstrumentorImpl._instance;
   }
@@ -104,7 +102,7 @@ class LangChainTraceInstrumentorImpl extends InstrumentationBase<Instrumentation
         this: CallbackManagerModuleType,
         ...args: Parameters<typeof CallbackManager["_configureSync"]>
       ) {
-        args[0] = addTracerToHandlers(instrumentor.otelTracer, args[0], { isContentRecordingEnabled: instrumentor.isContentRecordingEnabled });
+        args[0] = addTracerToHandlers(instrumentor.otelTracer, args[0]);
         logger.info("[LangChainTraceInstrumentor] _configureSync wrapped to add LangChainTracer");
         return original.apply(this, args);
       };
@@ -156,8 +154,8 @@ export class LangChainTraceInstrumentor {
    * @param module The CallbackManager module to instrument
    * @param options Optional configuration options
    */
-  static instrument(module: CallbackManagerModuleType, options?: { isContentRecordingEnabled?: boolean }): void {
-    LangChainTraceInstrumentorImpl.getInstance(options).manuallyInstrumentImpl(module);
+  static instrument(module: CallbackManagerModuleType): void {
+    LangChainTraceInstrumentorImpl.getInstance().manuallyInstrumentImpl(module);
   }
 
   /**
@@ -191,21 +189,20 @@ export class LangChainTraceInstrumentor {
 export function addTracerToHandlers(
   tracer: Tracer,
   handlers: CallbackManagerModule.Callbacks | undefined,
-  options?: { isContentRecordingEnabled?: boolean }
 ): CallbackManagerModule.Callbacks {
   if (handlers == null) {
-    return [new LangChainTracer(tracer, options)];
+    return [new LangChainTracer(tracer)];
   }
 
   if (Array.isArray(handlers)) {
     if (!handlers.some((h) => h instanceof LangChainTracer)) {
-      handlers.push(new LangChainTracer(tracer, options));
+      handlers.push(new LangChainTracer(tracer));
     }
     return handlers;
   }
 
   if (!handlers.inheritableHandlers.some((h) => h instanceof LangChainTracer)) {
-    handlers.addHandler(new LangChainTracer(tracer, options), true);
+    handlers.addHandler(new LangChainTracer(tracer), true);
   }
   return handlers;
 }

--- a/packages/agents-a365-observability-extensions-langchain/src/LangChainTraceInstrumentor.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/LangChainTraceInstrumentor.ts
@@ -152,7 +152,6 @@ export class LangChainTraceInstrumentor {
   /**
    * Initialize and auto-instrument for LangChain
    * @param module The CallbackManager module to instrument
-   * @param options Optional configuration options
    */
   static instrument(module: CallbackManagerModuleType): void {
     LangChainTraceInstrumentorImpl.getInstance().manuallyInstrumentImpl(module);

--- a/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
@@ -5,8 +5,8 @@ import { Run } from "@langchain/core/tracers/base";
 import { Span } from "@opentelemetry/api";
 import {
   OpenTelemetryConstants,
-  truncateValue,
   serializeMessages,
+  safeSerializeToJson,
   A365_MESSAGE_SCHEMA_VERSION,
   MessageRole,
 } from "@microsoft/agents-a365-observability";
@@ -64,14 +64,23 @@ export function setToolAttributes(run: Run, span: Span) {
   if (isString(run.name))  {
     span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_NAME_KEY, run.name);
   }
-  if (run.inputs) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY, truncateValue(JSON.stringify(run.inputs?.input ?? run.inputs)));
+  if (run.inputs) {
+    const argsValue = run.inputs?.input ?? run.inputs;
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY, safeSerializeToJson(
+      typeof argsValue === 'object' ? argsValue as Record<string, unknown> : String(argsValue), 'arguments'
+    ));
+  }
 
   // Tool result: v0 uses output.kwargs.content, v1 returns output as a plain string or has content directly
   const toolResult =
     run.outputs?.output?.kwargs?.content ??
     (isString(run.outputs?.output) ? run.outputs.output : null) ??
     run.outputs?.output?.content;
-  if (toolResult != null) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY, truncateValue(isString(toolResult) ? toolResult : JSON.stringify(toolResult)));
+  if (toolResult != null) {
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY, safeSerializeToJson(
+      typeof toolResult === 'object' ? toolResult as Record<string, unknown> : String(toolResult), 'result'
+    ));
+  }
 
   span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, "extension");
 
@@ -106,7 +115,7 @@ export function setInputMessagesAttribute(run: Run, span: Span) {
 
   if (chatMessages.length > 0) {
     const wrapper: InputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: chatMessages };
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrapper)));
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, serializeMessages(wrapper));
   }
 }
 
@@ -382,7 +391,7 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
 
   if (outputMessages.length > 0) {
     const wrapper: OutputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: outputMessages };
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrapper)));
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(wrapper));
   }
 }
 
@@ -437,7 +446,7 @@ export function setSystemInstructionsAttribute(run: Run, span: Span) {
   }
 
   const prompts = Array.isArray(inputs.prompts) ? inputs.prompts.map(p => String(p ?? "").trim()).filter(Boolean).join("\n") : "";
-  if (prompts) return span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, truncateValue(prompts));
+  if (prompts) return span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, prompts);
 
   // Check both flat and nested message arrays
   const rawMessages = Array.isArray(inputs.messages) ? inputs.messages : [];
@@ -452,7 +461,7 @@ export function setSystemInstructionsAttribute(run: Run, span: Span) {
     .map((s: string) => s.trim())
     .filter(Boolean)
     .join("\n");
-  if (systemText) span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, truncateValue(systemText));
+  if (systemText) span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, systemText);
 }
 
 // Tokens (input and output)

--- a/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
@@ -110,25 +110,10 @@ export function setInputMessagesAttribute(run: Run, span: Span) {
   }
 }
 
-// Helper: Extract message content from various formats
-function extractMessageContent(msg: Record<string, unknown>): string | null {
-  // Simple format: {role: "user", content}
-  if (isString(msg.content)) {
-    return msg.content;
-  }
-
-  // LangChain format: {lc_type: "human", lc_kwargs: {content}}
-  if (msg.lc_kwargs && typeof msg.lc_kwargs === "object" && !Array.isArray(msg.lc_kwargs)) {
-    const kwargs = msg.lc_kwargs as Record<string, unknown>;
-    if (isString(kwargs.content)) return kwargs.content;
-  }
-
-  // LangChain v1 serialized format — see extractMessageContent for details
-  if (msg.lc === 1 && msg.type === "constructor" && msg.kwargs && typeof msg.kwargs === "object" && !Array.isArray(msg.kwargs)) {
-    const kwargs = msg.kwargs as Record<string, unknown>;
-    if (isString(kwargs.content)) return kwargs.content;
-  }
-  return null;
+// Helper: Extract string content from a message (used for fallback text extraction and system instructions)
+function extractStringContent(msg: Record<string, unknown>): string | null {
+  const raw = extractRawContent(msg);
+  return isString(raw) ? raw : null;
 }
 
 // Helper: Extract raw content (string or content block array) from various message formats
@@ -251,7 +236,7 @@ function buildPartsFromMessage(msg: Record<string, unknown>): MessagePart[] {
 
   // Fallback: if no parts were built, use text extraction
   if (parts.length === 0) {
-    const textContent = extractMessageContent(msg);
+    const textContent = extractStringContent(msg);
     if (textContent) {
       parts.push({ type: "text", content: textContent });
     }
@@ -301,14 +286,16 @@ function getMessageType(msg: Record<string, unknown>): string {
   if (isString(msg.role)) return msg.role;
   // LangChain old format
   if (isString(msg.lc_type)) return msg.lc_type;
-  if (isString(msg.type)) return msg.type;
-  // LangChain new format - check id array for message type
+  // Skip v1 constructor type marker — fall through to id array check
+  if (isString(msg.type) && msg.type !== "constructor") return msg.type;
+  // LangChain v1 format - check id array for message type (e.g., ["langchain_core", "messages", "HumanMessage"])
   if (Array.isArray(msg.id)) {
     const lastId = msg.id[msg.id.length - 1];
     if (isString(lastId)) {
       if (lastId.includes("Human")) return "human";
       if (lastId.includes("AI")) return "ai";
       if (lastId.includes("System")) return "system";
+      if (lastId.includes("Tool")) return "tool";
     }
   }
   return "unknown";
@@ -461,7 +448,7 @@ export function setSystemInstructionsAttribute(run: Run, span: Span) {
       const msgType = getMessageType(m as Record<string, unknown>);
       return msgType === "system";
     })
-    .map((m: unknown) => extractMessageContent(m as Record<string, unknown>) ?? "")
+    .map((m: unknown) => extractStringContent(m as Record<string, unknown>) ?? "")
     .map((s: string) => s.trim())
     .filter(Boolean)
     .join("\n");
@@ -490,11 +477,15 @@ export function setTokenAttributes(run: Run, span: Span) {
   }
 
   const usageObj = usage as Record<string, unknown>;
-  if (typeof usageObj.input_tokens === "number") {
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY, usageObj.input_tokens);
+  // Support both usage_metadata shape (input_tokens/output_tokens) and
+  // tokenUsage shape (promptTokens/completionTokens) from LangChain OpenAI provider
+  const inputTokens = usageObj.input_tokens ?? usageObj.promptTokens;
+  const outputTokens = usageObj.output_tokens ?? usageObj.completionTokens;
+  if (typeof inputTokens === "number") {
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY, inputTokens);
   }
-  if (typeof usageObj.output_tokens === "number") {
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY, usageObj.output_tokens);
+  if (typeof outputTokens === "number") {
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY, outputTokens);
   }
 }
 

--- a/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
@@ -3,7 +3,20 @@
 
 import { Run } from "@langchain/core/tracers/base";
 import { Span } from "@opentelemetry/api";
-import { OpenTelemetryConstants, truncateValue } from "@microsoft/agents-a365-observability";
+import {
+  OpenTelemetryConstants,
+  truncateValue,
+  serializeMessages,
+  A365_MESSAGE_SCHEMA_VERSION,
+  MessageRole,
+} from "@microsoft/agents-a365-observability";
+import type {
+  ChatMessage,
+  OutputMessage,
+  InputMessages,
+  OutputMessages,
+  MessagePart,
+} from "@microsoft/agents-a365-observability";
 
 // Type guards
 export function isString(value: unknown): value is string {
@@ -48,13 +61,23 @@ export function setToolAttributes(run: Run, span: Span) {
     return;
   }
 
-  if (isString(run.name))  { 
+  if (isString(run.name))  {
     span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_NAME_KEY, run.name);
   }
   if (run.inputs) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY, truncateValue(JSON.stringify(run.inputs?.input ?? run.inputs)));
-  if (run.outputs?.output?.kwargs?.content) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY, truncateValue(JSON.stringify(run.outputs?.output?.kwargs?.content)));
-  span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, "extension");  
-  if (run.outputs?.output?.tool_call_id) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_ID_KEY, run.outputs?.output?.tool_call_id);
+
+  // Tool result: v0 uses output.kwargs.content, v1 returns output as a plain string or has content directly
+  const toolResult =
+    run.outputs?.output?.kwargs?.content ??
+    (isString(run.outputs?.output) ? run.outputs.output : null) ??
+    run.outputs?.output?.content;
+  if (toolResult != null) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY, truncateValue(isString(toolResult) ? toolResult : JSON.stringify(toolResult)));
+
+  span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, "extension");
+
+  // Tool call ID: v0 uses output.tool_call_id, v1 may have it on inputs
+  const toolCallId = run.outputs?.output?.tool_call_id ?? run.inputs?.tool_call_id;
+  if (toolCallId) span.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_CALL_ID_KEY, toolCallId);
 }
 
 export function setInputMessagesAttribute(run: Run, span: Span) {
@@ -63,21 +86,27 @@ export function setInputMessagesAttribute(run: Run, span: Span) {
     return;
   }
 
-  const preprocess = getScopeType(run) === "inference" && messages.length > 0 ? messages[0] : messages;
-  const processed = preprocess?.map((msg: Record<string, unknown>) => {
-      const content = extractMessageContent(msg);
-      if (!content) return null;
+  // LangChain may provide messages as a direct array or as a single nested array.
+  // Normalize both shapes so agent/inference inputs are consistently processed.
+  const preprocess = getScopeType(run) !== "unknown" &&  messages.length > 0 && Array.isArray(messages[0])
+    ? messages[0] as unknown[]
+    : messages;
+  const chatMessages: ChatMessage[] = [];
 
-      const msgType = getMessageType(msg);
-      if (shouldIncludeInputMessage(msgType)) {
-        return content;
-      }
-      return null;
-    })
-    .filter(Boolean);
+  for (const msg of preprocess) {
+    if (!msg || typeof msg !== "object") continue;
+    const msgObj = msg as Record<string, unknown>;
+    const parts = buildPartsFromMessage(msgObj);
+    if (parts.length === 0) continue;
 
-  if (processed.length > 0) {
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(JSON.stringify(processed)));
+    const msgType = getMessageType(msgObj);
+    const role = mapLangChainRole(msgType);
+    chatMessages.push({ role, parts });
+  }
+
+  if (chatMessages.length > 0) {
+    const wrapper: InputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: chatMessages };
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrapper)));
   }
 }
 
@@ -94,12 +123,176 @@ function extractMessageContent(msg: Record<string, unknown>): string | null {
     if (isString(kwargs.content)) return kwargs.content;
   }
 
-  // New LangChain format: {lc: 1, type: "constructor", kwargs: {content}}
+  // LangChain v1 serialized format — see extractMessageContent for details
   if (msg.lc === 1 && msg.type === "constructor" && msg.kwargs && typeof msg.kwargs === "object" && !Array.isArray(msg.kwargs)) {
     const kwargs = msg.kwargs as Record<string, unknown>;
     if (isString(kwargs.content)) return kwargs.content;
   }
   return null;
+}
+
+// Helper: Extract raw content (string or content block array) from various message formats
+function extractRawContent(msg: Record<string, unknown>): string | unknown[] | null {
+  // Simple format: {role: "user", content: string | array}
+  if (msg.content !== undefined && msg.content !== null) {
+    if (isString(msg.content)) return msg.content;
+    if (Array.isArray(msg.content)) return msg.content;
+  }
+
+  // LangChain format: {lc_type: "human", lc_kwargs: {content}}
+  if (msg.lc_kwargs && typeof msg.lc_kwargs === "object" && !Array.isArray(msg.lc_kwargs)) {
+    const kwargs = msg.lc_kwargs as Record<string, unknown>;
+    if (isString(kwargs.content)) return kwargs.content;
+    if (Array.isArray(kwargs.content)) return kwargs.content;
+  }
+
+  // LangChain v1 serialized class instance format: { lc: 1, type: "constructor", kwargs: {...} }
+  // `lc: 1` is the LangChain serialization version marker indicating a v1 schema.
+  // `type: "constructor"` means the object was serialized as a class instance (e.g. HumanMessage, AIMessage)
+  // that can be reconstructed via its constructor arguments stored in `kwargs`.
+  if (msg.lc === 1 && msg.type === "constructor" && msg.kwargs && typeof msg.kwargs === "object" && !Array.isArray(msg.kwargs)) {
+    const kwargs = msg.kwargs as Record<string, unknown>;
+    if (isString(kwargs.content)) return kwargs.content;
+    if (Array.isArray(kwargs.content)) return kwargs.content;
+  }
+  return null;
+}
+
+// Helper: Map LangChain message type to MessageRole
+function mapLangChainRole(msgType: string): MessageRole | string {
+  switch (msgType) {
+  case "user":
+  case "human":
+    return MessageRole.USER;
+  case "assistant":
+  case "ai":
+    return MessageRole.ASSISTANT;
+  case "system":
+    return MessageRole.SYSTEM;
+  case "tool":
+    return MessageRole.TOOL;
+  default:
+    return msgType;
+  }
+}
+
+// Helper: Build MessagePart[] from a LangChain message
+function buildPartsFromMessage(msg: Record<string, unknown>): MessagePart[] {
+  const parts: MessagePart[] = [];
+  const rawContent = extractRawContent(msg);
+
+  const addUnknownBlockPart = (blockType: string, block: Record<string, unknown>) => {
+    try {
+      parts.push({ type: blockType, content: JSON.stringify(block) } as MessagePart);
+    } catch {
+      parts.push({ type: blockType, content: "[unserializable]" } as MessagePart);
+    }
+  };
+
+  const addPartFromContentBlock = (block: unknown) => {
+    if (!block || typeof block !== "object") return;
+
+    const contentBlock = block as Record<string, unknown>;
+    const blockType = contentBlock.type as string | undefined;
+    if (!blockType) return;
+
+    if (blockType === "text" && isString(contentBlock.text)) {
+      parts.push({ type: "text", content: contentBlock.text });
+      return;
+    }
+
+    if (blockType === "reasoning" && isString(contentBlock.reasoning)) {
+      parts.push({ type: "reasoning", content: contentBlock.reasoning });
+      return;
+    }
+
+    if (blockType === "tool_call") {
+      parts.push({
+        type: "tool_call",
+        name: String(contentBlock.name ?? ""),
+        id: contentBlock.id != null ? String(contentBlock.id) : undefined,
+        arguments: contentBlock.args && typeof contentBlock.args === "object" ? contentBlock.args as Record<string, unknown> : undefined,
+      });
+      return;
+    }
+
+    addUnknownBlockPart(blockType, contentBlock);
+  };
+
+  if (isString(rawContent)) {
+    parts.push({ type: "text", content: rawContent });
+  } else if (Array.isArray(rawContent)) {
+    for (const block of rawContent) {
+      addPartFromContentBlock(block);
+    }
+  }
+
+  // Extract tool_calls from the message (AI messages may have a separate tool_calls array)
+  // Deduplicate by ID to avoid duplicates when tool_calls appear in both content blocks and tool_calls array
+  const seenToolCallIds = new Set<string>();
+  for (const part of parts) {
+    if (part.type !== "tool_call") continue;
+    const partId = (part as Record<string, unknown>).id;
+    if (isString(partId)) {
+      seenToolCallIds.add(partId);
+    }
+  }
+
+  for (const toolCall of extractToolCalls(msg)) {
+    const toolCallId = (toolCall as Record<string, unknown>).id;
+    if (isString(toolCallId) && seenToolCallIds.has(toolCallId)) {
+      continue;
+    }
+    if (isString(toolCallId)) {
+      seenToolCallIds.add(toolCallId);
+    }
+    parts.push(toolCall);
+  }
+
+  // Fallback: if no parts were built, use text extraction
+  if (parts.length === 0) {
+    const textContent = extractMessageContent(msg);
+    if (textContent) {
+      parts.push({ type: "text", content: textContent });
+    }
+  }
+
+  return parts;
+}
+
+// Helper: Extract tool_calls from a LangChain message
+function extractToolCalls(msg: Record<string, unknown>): MessagePart[] {
+  const parts: MessagePart[] = [];
+
+  // Standard format: message.tool_calls[] — check direct, lc_kwargs, and kwargs paths
+  const directToolCalls =
+    getNestedValue(msg, "tool_calls") ??
+    getNestedValue(msg, "lc_kwargs", "tool_calls") ??
+    getNestedValue(msg, "kwargs", "tool_calls");
+  if (Array.isArray(directToolCalls)) {
+    for (const tc of directToolCalls) {
+      if (!tc || typeof tc !== "object") continue;
+      const call = tc as Record<string, unknown>;
+      parts.push({
+        type: "tool_call",
+        name: String(call.name ?? ""),
+        id: call.id != null ? String(call.id) : undefined,
+        arguments: call.args && typeof call.args === "object" ? call.args as Record<string, unknown> : undefined,
+      });
+    }
+  }
+
+  return parts;
+}
+
+// Helper: Safely get a nested value from a message object
+function getNestedValue(obj: Record<string, unknown>, ...keys: string[]): unknown {
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
 }
 
 // Helper: Determine message type
@@ -133,12 +326,6 @@ function getScopeType(run: Run): "agent" | "tool" | "inference" | "unknown" {
   return "unknown";
 }
 
-// Helper: Check if input message should be included based on scope and message type
-function shouldIncludeInputMessage(msgType: string): boolean {
-  // For input messages: all scopes want user/human messages only
-  return msgType === "user" || msgType === "human";
-}
-
 // Helper: Check if output message should be included based on scope and message type
 function shouldIncludeOutputMessage(scopeType: string, msgType: string): boolean {
   if (scopeType === "agent" || scopeType === "inference") {
@@ -159,19 +346,25 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
   }
 
   const scopeType = getScopeType(run);
-  const messages: string[] = [];
+  const outputMessages: OutputMessage[] = [];
+
+  // Helper: process a single message object into an OutputMessage
+  const processMessage = (msg: Record<string, unknown>) => {
+    const msgType = getMessageType(msg);
+    if (!shouldIncludeOutputMessage(scopeType, msgType)) return;
+
+    const parts = buildPartsFromMessage(msg);
+    if (parts.length === 0) return;
+
+    const role = mapLangChainRole(msgType);
+    outputMessages.push({ role, parts });
+  };
 
   // Direct messages array (used in agent/chain outputs)
   if (Array.isArray(outputs.messages)) {
-    outputs.messages.forEach((msg: Record<string, unknown>) => {
-      const content = extractMessageContent(msg);
-      if (!content) return;
-
-      const msgType = getMessageType(msg);
-      if (shouldIncludeOutputMessage(scopeType, msgType)) {
-        messages.push(content);
-      }
-    });
+     for (const msg of outputs.messages as Record<string, unknown>[]) {
+      processMessage(msg);
+     }
   }
 
   // LangChain generations format (used in LLM/inference outputs)
@@ -181,20 +374,14 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
         gen.forEach((item: Record<string, unknown>) => {
           // Try message property
           if (item.message && typeof item.message === "object" && !Array.isArray(item.message)) {
-            const msg = item.message as Record<string, unknown>;
-            const content = extractMessageContent(msg);
-            if (!content) { 
-              return;
-            }
-
-            const msgType = getMessageType(msg);
-            if (shouldIncludeOutputMessage(scopeType, msgType)) {
-              messages.push(content);
-            }
+            processMessage(item.message as Record<string, unknown>);
           }
           // Try direct text property (for generation items)
           else if (isString(item.text) && scopeType === "inference") {
-            messages.push(item.text);
+            outputMessages.push({
+              role: MessageRole.ASSISTANT,
+              parts: [{ type: "text", content: item.text }],
+            });
           }
         });
       }
@@ -203,29 +390,29 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
 
   // Check for direct message object (some models return this)
   if (outputs.message && typeof outputs.message === "object" && !Array.isArray(outputs.message)) {
-    const msg = outputs.message as Record<string, unknown>;
-    const content = extractMessageContent(msg);
-    if (content) {
-      const msgType = getMessageType(msg);
-      if (shouldIncludeOutputMessage(scopeType, msgType)) {
-        messages.push(content);
-      }
-    }
+    processMessage(outputs.message as Record<string, unknown>);
   }
 
-  if (messages.length > 0) {
-    span.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(JSON.stringify(messages)));
+  if (outputMessages.length > 0) {
+    const wrapper: OutputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: outputMessages };
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrapper)));
   }
 }
 
 // Model - Helper to extract model name from run
 export function getModel(run: Run): string | undefined {
-  return [run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.response_metadata?.model_name,
-     run.extra?.metadata?.ls_model_name,
-     run.extra?.invocation_params?.model,
-     run.extra?.invocation_params?.model_name]
-      .map((v) => (v != null ? String(v).trim() : ""))
-      .find((v) => v.length > 0);
+  return [
+    // v1: response_metadata directly on message
+    run.outputs?.generations?.[0]?.[0]?.message?.response_metadata?.model_name,
+    // v0: response_metadata nested under kwargs
+    run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.response_metadata?.model_name,
+    // Metadata paths (both v0 and v1)
+    run.extra?.metadata?.ls_model_name,
+    run.extra?.invocation_params?.model,
+    run.extra?.invocation_params?.model_name,
+  ]
+    .map((v) => (v != null ? String(v).trim() : ""))
+    .find((v) => v.length > 0);
 }
 
 // Model - Set model attribute on span
@@ -265,10 +452,17 @@ export function setSystemInstructionsAttribute(run: Run, span: Span) {
   const prompts = Array.isArray(inputs.prompts) ? inputs.prompts.map(p => String(p ?? "").trim()).filter(Boolean).join("\n") : "";
   if (prompts) return span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, truncateValue(prompts));
 
-  const messages = Array.isArray(inputs.messages) ? inputs.messages : [];
-  const systemText = messages
-    .filter((m: Record<string, unknown>) => m.lc_type === "system")
-    .map((m: Record<string, unknown>) => String((m.lc_kwargs as Record<string, unknown> | undefined)?.content ?? "").trim())
+  // Check both flat and nested message arrays
+  const rawMessages = Array.isArray(inputs.messages) ? inputs.messages : [];
+  const flatMessages = rawMessages.length > 0 && Array.isArray(rawMessages[0]) ? rawMessages[0] as unknown[] : rawMessages;
+  const systemText = flatMessages
+    .filter((m: unknown) => {
+      if (!m || typeof m !== "object") return false;
+      const msgType = getMessageType(m as Record<string, unknown>);
+      return msgType === "system";
+    })
+    .map((m: unknown) => extractMessageContent(m as Record<string, unknown>) ?? "")
+    .map((s: string) => s.trim())
     .filter(Boolean)
     .join("\n");
   if (systemText) span.setAttribute(OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY, truncateValue(systemText));
@@ -277,11 +471,14 @@ export function setSystemInstructionsAttribute(run: Run, span: Span) {
 // Tokens (input and output)
 export function setTokenAttributes(run: Run, span: Span) {
   // Try multiple paths to find usage metadata (LLM direct/kwargs/response_metadata, agent calls, and chain/model_request outputs)
-  const usage = 
+  // v1: usage_metadata is often on the last AI message in outputs.messages
+  const lastMsg = Array.isArray(run.outputs?.messages) ? run.outputs.messages[run.outputs.messages.length - 1] : undefined;
+  const usage =
     run.outputs?.generations?.[0]?.[0]?.message?.usage_metadata ||
     run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.usage_metadata ||
+    run.outputs?.generations?.[0]?.[0]?.message?.response_metadata?.tokenUsage ||
     run.outputs?.generations?.[0]?.[0]?.message?.kwargs?.response_metadata?.tokenUsage ||
-    run.outputs?.messages?.[1]?.usage_metadata ||
+    lastMsg?.usage_metadata ||
     run.outputs?.message?.response_metadata?.usage ||
     run.outputs?.message?.response_metadata?.tokenUsage ||
     run.outputs?.messages

--- a/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
@@ -4,7 +4,7 @@
 import { context, trace, Span, SpanKind, SpanStatusCode, Tracer } from "@opentelemetry/api";
 import { BaseTracer, Run } from "@langchain/core/tracers/base";
 import { isTracingSuppressed } from "@opentelemetry/core";
-import { logger, OpenTelemetryConstants, truncateValue } from "@microsoft/agents-a365-observability";
+import { logger, OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
 import * as Utils from "./Utils";
 
 type RunWithSpan = { run: Run; span: Span; startTime: number; lastAccessTime: number };
@@ -12,15 +12,13 @@ type RunWithSpan = { run: Run; span: Span; startTime: number; lastAccessTime: nu
 export class LangChainTracer extends BaseTracer {
   private static readonly MAX_RUNS = 10_000;
   private tracer: Tracer;
-  private isContentRecordingEnabled: boolean;
   private runs = new Map<string, RunWithSpan>();
   private parentByRunId = new Map<string, string | undefined>();
 
 
-  constructor(tracer: Tracer, options?: { isContentRecordingEnabled?: boolean }) {
+  constructor(tracer: Tracer) {
     super();
     this.tracer = tracer;
-    this.isContentRecordingEnabled = options?.isContentRecordingEnabled ?? false;
   }
 
   name = "OpenTelemetryLangChainTracer";
@@ -108,7 +106,7 @@ export class LangChainTracer extends BaseTracer {
 
       if (run.error) {
         span.setStatus({ code: SpanStatusCode.ERROR });
-        span.setAttribute(OpenTelemetryConstants.ERROR_MESSAGE_KEY, truncateValue(String(run.error)));
+        span.setAttribute(OpenTelemetryConstants.ERROR_MESSAGE_KEY, String(run.error));
 
       } else {
         span.setStatus({ code: SpanStatusCode.OK });
@@ -122,14 +120,11 @@ export class LangChainTracer extends BaseTracer {
       Utils.setSessionIdAttribute(run, span);
       Utils.setTokenAttributes(run, span);
 
-      // Content attributes gated by content recording setting
-      const contentRecording = this.isContentRecordingEnabled;
-      if (contentRecording) {
-        Utils.setToolAttributes(run, span);
-        Utils.setInputMessagesAttribute(run, span);
-        Utils.setOutputMessagesAttribute(run, span);
-        Utils.setSystemInstructionsAttribute(run, span);
-      }
+      // Content attributes — always recorded (aligned with Python/.NET SDKs)
+      Utils.setToolAttributes(run, span);
+      Utils.setInputMessagesAttribute(run, span);
+      Utils.setOutputMessagesAttribute(run, span);
+      Utils.setSystemInstructionsAttribute(run, span);
 
     } catch (error) {
       logger.error(`[LangChainTracer] Error setting span attributes for run ${run.name}: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceInstrumentor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceInstrumentor.ts
@@ -27,11 +27,6 @@ export interface OpenAIAgentsInstrumentationConfig extends InstrumentationConfig
    * Defaults to false.
    */
   suppressInvokeAgentInput?: boolean;
-  /**
-   * Whether to enable content recording (input/output messages, tool args, etc.).
-   * @default false
-   */
-  isContentRecordingEnabled?: boolean;
 }
 
 /**
@@ -106,7 +101,6 @@ export class OpenAIAgentsTraceInstrumentor extends InstrumentationBase<OpenAIAge
 
     this.processor = new OpenAIAgentsTraceProcessor(agent365Tracer, {
       suppressInvokeAgentInput: this._config.suppressInvokeAgentInput ?? false,
-      isContentRecordingEnabled: this._config.isContentRecordingEnabled ?? false,
     });
 
     // Register the processor directly using the imported setTraceProcessors function

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -11,7 +11,7 @@ import { context, trace as OtelTrace, Span as OtelSpan, Tracer as OtelTracer } f
 import { OpenTelemetryConstants, InferenceOperationType, logger, truncateValue, serializeMessages } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
 import * as Utils from './Utils';
-import { buildStructuredInputMessages, buildStructuredOutputMessages } from './Utils';
+import { buildStructuredInputMessages, buildStructuredOutputMessages, wrapRawContentAsInputMessages, wrapRawContentAsOutputMessages } from './Utils';
 import {
   Span as AgentsSpan,
   SpanData,
@@ -249,10 +249,11 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     if (responseObj) {
       const resp = responseObj as Record<string, unknown>;
 
-      // Store the output field as structured OutputMessages
+      // Store the output field as structured OutputMessages (always use versioned envelope)
       if (resp.output && contentRecording) {
         if (typeof resp.output === 'string') {
-          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(resp.output));
+          const structured = wrapRawContentAsOutputMessages(resp.output);
+          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(serializeMessages(structured)));
         } else if (Array.isArray(resp.output)) {
           const structured = buildStructuredOutputMessages(resp.output as Array<Record<string, unknown>>);
           otelSpan.setAttribute(
@@ -288,9 +289,10 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
             return;
           }
         } catch {
-          // If parsing fails, fall back to raw string behavior
+          // If parsing fails, wrap raw string in versioned envelope
         }
-        otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(inputObj as string));
+        const wrappedInput = wrapRawContentAsInputMessages(inputObj);
+        otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrappedInput)));
       } else if (Array.isArray(inputObj)) {
         const structured = buildStructuredInputMessages(inputObj as Array<{ role: string; content: string | unknown[] | unknown }>);
         otelSpan.setAttribute(
@@ -343,8 +345,8 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
           otelSpan.setAttribute(resolvedKey, value as string | number | boolean);
         }
       }
-      otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, 'function');
     });
+    otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, 'function');
 
     this.stampCustomParent(otelSpan, traceId);
     // Use function name from data instead of span name

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -235,15 +235,16 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
 
       // Store the output field as structured OutputMessages (always use versioned envelope)
       if (resp.output != null) {
-        if (typeof resp.output === 'string') {
-          const structured = wrapRawContentAsOutputMessages(resp.output);
-          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(structured));
-        } else if (Array.isArray(resp.output)) {
+        if (Array.isArray(resp.output)) {
           const structured = buildStructuredOutputMessages(resp.output as Array<Record<string, unknown>>);
           otelSpan.setAttribute(
             OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
             serializeMessages(structured)
           );
+        } else {
+          // String or non-array object — wrap as raw content
+          const structured = wrapRawContentAsOutputMessages(resp.output);
+          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(structured));
         }
       }
 

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -8,7 +8,7 @@
  */
 
 import { context, trace as OtelTrace, Span as OtelSpan, Tracer as OtelTracer } from '@opentelemetry/api';
-import { OpenTelemetryConstants, InferenceOperationType, logger, truncateValue, serializeMessages } from '@microsoft/agents-a365-observability';
+import { OpenTelemetryConstants, InferenceOperationType, logger, serializeMessages } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
 import * as Utils from './Utils';
 import { buildStructuredInputMessages, buildStructuredOutputMessages, wrapRawContentAsInputMessages, wrapRawContentAsOutputMessages } from './Utils';
@@ -34,7 +34,6 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
 
   private readonly tracer: OtelTracer;
   private readonly suppressInvokeAgentInput: boolean;
-  private readonly isContentRecordingEnabled: boolean;
   private readonly rootSpans: Map<string, OtelSpan> = new Map();
   private readonly otelSpans: Map<string, OtelSpan> = new Map();
   private readonly tokens: Map<string, ContextToken> = new Map();
@@ -51,23 +50,9 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     ['generation' + Constants.GEN_AI_REQUEST_CONTENT_KEY, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY],
   ]);
 
-  constructor(tracer: OtelTracer, options?: { suppressInvokeAgentInput?: boolean; isContentRecordingEnabled?: boolean }) {
+  constructor(tracer: OtelTracer, options?: { suppressInvokeAgentInput?: boolean }) {
     this.tracer = tracer;
     this.suppressInvokeAgentInput = options?.suppressInvokeAgentInput ?? false;
-    this.isContentRecordingEnabled = options?.isContentRecordingEnabled ?? false;
-  }
-
-  private static readonly CONTENT_KEYS = new Set([
-    OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-    OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-    OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY,
-    OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY,
-    Constants.GEN_AI_REQUEST_CONTENT_KEY,
-    Constants.GEN_AI_RESPONSE_CONTENT_KEY,
-  ]);
-
-  private static isContentKey(key: string): boolean {
-    return OpenAIAgentsTraceProcessor.CONTENT_KEYS.has(key);
   }
 
   private getNewKey(spanType: string, key: string): string | null {
@@ -209,19 +194,18 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
    */
   private processSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string): void {
     const type = data.type;
-    const contentRecording = this.isContentRecordingEnabled;
 
     switch (type) {
     case 'response':
-      this.processResponseSpanData(otelSpan, data, contentRecording);
+      this.processResponseSpanData(otelSpan, data);
       break;
 
     case 'generation':
-      this.processGenerationSpanData(otelSpan, data, traceId, contentRecording);
+      this.processGenerationSpanData(otelSpan, data, traceId);
       break;
 
     case 'function':
-      this.processFunctionSpanData(otelSpan, data, traceId, contentRecording);
+      this.processFunctionSpanData(otelSpan, data, traceId);
       break;
 
     case 'mcp_tools':
@@ -241,7 +225,7 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   /**
    * Process response span data
    */
-  private processResponseSpanData(otelSpan: OtelSpan, data: SpanData, contentRecording: boolean): void {
+  private processResponseSpanData(otelSpan: OtelSpan, data: SpanData): void {
     const responseData = data as Record<string, unknown>;
     // Handle both formats: _response/_input (actual format) and response/input (legacy format)
     const responseObj = responseData._response || responseData.response;
@@ -250,15 +234,15 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
       const resp = responseObj as Record<string, unknown>;
 
       // Store the output field as structured OutputMessages (always use versioned envelope)
-      if (resp.output && contentRecording) {
+      if (resp.output != null) {
         if (typeof resp.output === 'string') {
           const structured = wrapRawContentAsOutputMessages(resp.output);
-          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(serializeMessages(structured)));
+          otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(structured));
         } else if (Array.isArray(resp.output)) {
           const structured = buildStructuredOutputMessages(resp.output as Array<Record<string, unknown>>);
           otelSpan.setAttribute(
             OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-            truncateValue(serializeMessages(structured))
+            serializeMessages(structured)
           );
         }
       }
@@ -276,7 +260,7 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
       otelSpan.updateName(`${InferenceOperationType.CHAT} ${modelName}`);
     }
 
-    if (inputObj && !this.suppressInvokeAgentInput && contentRecording) {
+    if (inputObj != null && !this.suppressInvokeAgentInput) {
       if (typeof inputObj === 'string') {
         try {
           const parsed = JSON.parse(inputObj as string);
@@ -284,7 +268,7 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
             const structured = buildStructuredInputMessages(parsed);
             otelSpan.setAttribute(
               OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-              truncateValue(serializeMessages(structured))
+              serializeMessages(structured)
             );
             return;
           }
@@ -292,12 +276,12 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
           // If parsing fails, wrap raw string in versioned envelope
         }
         const wrappedInput = wrapRawContentAsInputMessages(inputObj);
-        otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(serializeMessages(wrappedInput)));
+        otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, serializeMessages(wrappedInput));
       } else if (Array.isArray(inputObj)) {
         const structured = buildStructuredInputMessages(inputObj as Array<{ role: string; content: string | unknown[] | unknown }>);
         otelSpan.setAttribute(
           OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-          truncateValue(serializeMessages(structured))
+          serializeMessages(structured)
         );
       }
     }
@@ -306,7 +290,7 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   /**
    * Process generation span data
    */
-  private processGenerationSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string, contentRecording: boolean): void {
+  private processGenerationSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string): void {
     const attrs = Utils.getAttributesFromGenerationSpanData(data);
     Object.entries(attrs).forEach(([key, value]) => {
       const shouldExcludeKey = key === Constants.GEN_AI_EXECUTION_PAYLOAD_KEY;
@@ -314,9 +298,7 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
         const newKey = this.getNewKey(data.type, key);
         const resolvedKey = newKey || key;
         if (resolvedKey !== OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY || !this.suppressInvokeAgentInput) {
-          if (!OpenAIAgentsTraceProcessor.isContentKey(resolvedKey) || contentRecording) {
-            otelSpan.setAttribute(resolvedKey, value as string | number | boolean);
-          }
+          otelSpan.setAttribute(resolvedKey, value as string | number | boolean);
         }
       }
     });
@@ -334,16 +316,14 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   /**
    * Process function/tool span data
    */
-  private processFunctionSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string, contentRecording: boolean): void {
+  private processFunctionSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string): void {
     const functionData = data as Record<string, unknown>;
     const attrs = Utils.getAttributesFromFunctionSpanData(data);
     Object.entries(attrs).forEach(([key, value]) => {
       if (value !== null && value !== undefined) {
         const newKey = this.getNewKey(data.type, key);
         const resolvedKey = newKey || key;
-        if (!OpenAIAgentsTraceProcessor.isContentKey(resolvedKey) || contentRecording) {
-          otelSpan.setAttribute(resolvedKey, value as string | number | boolean);
-        }
+        otelSpan.setAttribute(resolvedKey, value as string | number | boolean);
       }
     });
     otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY, 'function');

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -8,9 +8,10 @@
  */
 
 import { context, trace as OtelTrace, Span as OtelSpan, Tracer as OtelTracer } from '@opentelemetry/api';
-import { OpenTelemetryConstants, InferenceOperationType, logger, truncateValue } from '@microsoft/agents-a365-observability';
+import { OpenTelemetryConstants, InferenceOperationType, logger, truncateValue, serializeMessages } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
 import * as Utils from './Utils';
+import { buildStructuredInputMessages, buildStructuredOutputMessages } from './Utils';
 import {
   Span as AgentsSpan,
   SpanData,
@@ -248,14 +249,15 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     if (responseObj) {
       const resp = responseObj as Record<string, unknown>;
 
-      // Store the output field for GEN_AI_RESPONSE_CONTENT_KEY
+      // Store the output field as structured OutputMessages
       if (resp.output && contentRecording) {
         if (typeof resp.output === 'string') {
           otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, truncateValue(resp.output));
-        } else {
+        } else if (Array.isArray(resp.output)) {
+          const structured = buildStructuredOutputMessages(resp.output as Array<Record<string, unknown>>);
           otelSpan.setAttribute(
             OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-            truncateValue(this.buildOutputMessages(resp.output  as Array<{ role: string; content: Array<{ type: string; text: string }> }>))
+            truncateValue(serializeMessages(structured))
           );
         }
       }
@@ -278,9 +280,10 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
         try {
           const parsed = JSON.parse(inputObj as string);
           if (Array.isArray(parsed)) {
+            const structured = buildStructuredInputMessages(parsed);
             otelSpan.setAttribute(
               OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-              truncateValue(this.buildInputMessages(parsed))
+              truncateValue(serializeMessages(structured))
             );
             return;
           }
@@ -289,39 +292,13 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
         }
         otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, truncateValue(inputObj as string));
       } else if (Array.isArray(inputObj)) {
-        // build the input messages from array
+        const structured = buildStructuredInputMessages(inputObj as Array<{ role: string; content: string | unknown[] | unknown }>);
         otelSpan.setAttribute(
           OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-          truncateValue(this.buildInputMessages(inputObj))
+          truncateValue(serializeMessages(structured))
         );
       }
     }
-  }
-
-  private buildInputMessages(arr: Array<{ role: string; content: string }>): string {
-    const userTexts = arr
-      .filter((m) => m && m.role === 'user' && typeof m.content === 'string')
-      .map((m) => m.content);
-
-    return JSON.stringify(userTexts.length ? userTexts : arr);
-  }
-
-  private buildOutputMessages(arr: Array<{ role: string; content: Array<{ type: string; text: string }> }>): string {
-    const userTexts: string[] = [];
-
-    for (const { content } of arr) {
-      if (!Array.isArray(content)) {
-        continue;
-      }
-
-      for (const { type, text } of content) {
-        if (type === 'output_text' && typeof text === 'string') {
-          userTexts.push(text);
-        }
-      }
-    }
-
-    return JSON.stringify(userTexts.length ? userTexts : arr);
   }
 
   /**

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -3,7 +3,16 @@
 // ------------------------------------------------------------------------------
 
 import { SpanStatusCode } from '@opentelemetry/api';
-import { OpenTelemetryConstants, truncateValue } from '@microsoft/agents-a365-observability';
+import {
+  OpenTelemetryConstants,
+  truncateValue,
+  serializeMessages,
+  A365_MESSAGE_SCHEMA_VERSION,
+  MessageRole,
+  InputMessages,
+  OutputMessages,
+} from '@microsoft/agents-a365-observability';
+import type { ChatMessage, OutputMessage, MessagePart } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
 import { Span as AgentsSpan, SpanData } from '@openai/agents-core/dist/tracing/spans';
 
@@ -88,11 +97,11 @@ export function getAttributesFromGenerationSpanData(data: SpanData): Record<stri
   }
 
   if (genData.input) {
-    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] = safeJsonDumps(genData.input);
+    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] = serializeMessages(wrapRawContentAsInputMessages(genData.input));
   }
 
   if (genData.output) {
-    attributes[Constants.GEN_AI_RESPONSE_CONTENT_KEY] = safeJsonDumps(genData.output);
+    attributes[Constants.GEN_AI_RESPONSE_CONTENT_KEY] = serializeMessages(wrapRawContentAsOutputMessages(genData.output));
   }
 
   if (genData.usage) {
@@ -200,4 +209,211 @@ export function getSpanStatus(span: AgentsSpan<SpanData>): { code: SpanStatusCod
   }
 
   return { code: SpanStatusCode.OK };
+}
+
+// ---------------------------------------------------------------------------
+// Structured message builders (OTEL gen-ai message format)
+// ---------------------------------------------------------------------------
+
+type OpenAIInputMessage = { role: string; content: string | unknown[] | unknown };
+type OpenAIOutputItem = { role?: string; content?: unknown[]; type?: string; text?: string; [key: string]: unknown };
+
+/**
+ * Map an OpenAI role string to a MessageRole value.
+ */
+function mapOpenAIRole(role: string): MessageRole | string {
+  switch (role) {
+  case 'user':
+    return MessageRole.USER;
+  case 'assistant':
+    return MessageRole.ASSISTANT;
+  case 'system':
+    return MessageRole.SYSTEM;
+  case 'tool':
+    return MessageRole.TOOL;
+  default:
+    return role;
+  }
+}
+
+function getModalityFromMimeType(mimeType: unknown): string {
+  return String(mimeType ?? 'file').split('/')[0] || 'file';
+}
+
+function mapGenericBlock(blockType: string | undefined, block: Record<string, unknown>): MessagePart {
+  return { type: blockType ?? 'unknown', content: safeJsonDumps(block) } as MessagePart;
+}
+
+function parseToolCallArguments(args: unknown): Record<string, unknown> | undefined {
+  if (typeof args === 'string') {
+    try {
+      return JSON.parse(args) as Record<string, unknown>;
+    } catch {
+      return { raw: args };
+    }
+  }
+
+  if (args && typeof args === 'object') {
+    return args as Record<string, unknown>;
+  }
+
+  return undefined;
+}
+
+function getToolCallId(block: Record<string, unknown>): string | undefined {
+  if (block.call_id != null) return String(block.call_id);
+  if (block.id != null) return String(block.id);
+  return undefined;
+}
+
+function wrapRawContentAsMessages(raw: unknown, role: MessageRole): InputMessages | OutputMessages {
+  const content = typeof raw === 'string' ? raw : safeJsonDumps(raw);
+  return {
+    version: A365_MESSAGE_SCHEMA_VERSION,
+    messages: [{ role, parts: [{ type: 'text', content }] }],
+  };
+}
+
+/**
+ * Map an OpenAI input content block to a MessagePart.
+ */
+function mapInputContentBlock(block: Record<string, unknown>): MessagePart {
+  const blockType = block.type as string | undefined;
+  switch (blockType) {
+  case 'input_text':
+    return { type: 'text', content: String(block.text ?? '') };
+  case 'input_image':
+    return { type: 'image' as string, modality: 'image', ...stripBinaryFields(block) } as MessagePart;
+  case 'input_file':
+    return {
+      type: 'file' as string,
+      modality: getModalityFromMimeType(block.mime_type),
+      ...stripBinaryFields(block),
+    } as MessagePart;
+  default:
+    return mapGenericBlock(blockType, block);
+  }
+}
+
+/**
+ * Strip large binary fields from a content block for telemetry.
+ */
+function stripBinaryFields(block: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(block)) {
+    if (key === 'type') continue;
+    if (typeof value === 'string' && value.length > 1024) {
+      result[key] = '[truncated]';
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Map an OpenAI output content block to a MessagePart.
+ */
+function mapOutputContentBlock(block: Record<string, unknown>): MessagePart {
+  const blockType = block.type as string | undefined;
+  switch (blockType) {
+  case 'output_text':
+    return { type: 'text', content: String(block.text ?? '') };
+  case 'refusal':
+    return { type: 'text', content: String(block.refusal ?? '') };
+  case 'tool_call':
+  case 'function_call': {
+    const parsedArgs = parseToolCallArguments(block.arguments ?? block.args);
+    return {
+      type: 'tool_call',
+      name: String(block.name ?? block.function ?? ''),
+      id: getToolCallId(block),
+      arguments: parsedArgs,
+    };
+  }
+  case 'reasoning':
+    return { type: 'reasoning', content: String(block.text ?? block.content ?? '') };
+  default:
+    return mapGenericBlock(blockType, block);
+  }
+}
+
+/**
+ * Build structured InputMessages from an OpenAI _input message array.
+ * Includes all roles (system, user, assistant, tool).
+ */
+export function buildStructuredInputMessages(
+  arr: OpenAIInputMessage[]
+): InputMessages {
+  const messages: ChatMessage[] = [];
+
+  for (const msg of arr) {
+    if (!msg || typeof msg !== 'object') continue;
+
+    const role = mapOpenAIRole(msg.role ?? 'user');
+    let parts: MessagePart[];
+
+    if (typeof msg.content === 'string') {
+      parts = [{ type: 'text', content: msg.content }];
+    } else if (Array.isArray(msg.content)) {
+      parts = (msg.content as Record<string, unknown>[]).map(mapInputContentBlock);
+    } else {
+      parts = [{ type: 'text', content: safeJsonDumps(msg.content) }];
+    }
+
+    messages.push({ role, parts });
+  }
+
+  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+}
+
+/**
+ * Build structured OutputMessages from an OpenAI response.output array.
+ */
+export function buildStructuredOutputMessages(
+  arr: OpenAIOutputItem[]
+): OutputMessages {
+  const messages: OutputMessage[] = [];
+
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+
+    const role = mapOpenAIRole(item.role ?? 'assistant');
+
+    // Items with a content array (standard response format)
+    if (Array.isArray(item.content)) {
+      const parts = (item.content as Record<string, unknown>[]).map(mapOutputContentBlock);
+      messages.push({ role, parts });
+      continue;
+    }
+
+    // Items that are themselves content blocks (e.g., type: 'message' with text)
+    if (item.type && typeof item.type === 'string') {
+      const parts = [mapOutputContentBlock(item as Record<string, unknown>)];
+      messages.push({ role, parts });
+      continue;
+    }
+
+    // Fallback: stringify the item
+    messages.push({
+      role,
+      parts: [{ type: 'text', content: safeJsonDumps(item) }],
+    });
+  }
+
+  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+}
+
+/**
+ * Wrap opaque raw content as InputMessages (for generation span data).
+ */
+export function wrapRawContentAsInputMessages(raw: unknown): InputMessages {
+  return wrapRawContentAsMessages(raw, MessageRole.USER) as InputMessages;
+}
+
+/**
+ * Wrap opaque raw content as OutputMessages (for generation span data).
+ */
+export function wrapRawContentAsOutputMessages(raw: unknown): OutputMessages {
+  return wrapRawContentAsMessages(raw, MessageRole.ASSISTANT) as OutputMessages;
 }

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -182,21 +182,6 @@ export function getAttributesFromResponse(response: unknown): Record<string, unk
 }
 
 /**
- * Get attributes from input data
- */
-export function getAttributesFromInput(input: unknown): Record<string, unknown> {
-  const attributes: Record<string, unknown> = {};
-
-  if (typeof input === 'string') {
-    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] = input;
-  } else if (Array.isArray(input)) {
-    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] = safeJsonDumps(input);
-  }
-
-  return attributes;
-}
-
-/**
  * Get span status from OpenAI Agents SDK span
  */
 export function getSpanStatus(span: AgentsSpan<SpanData>): { code: SpanStatusCode; message?: string } {

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -272,7 +272,7 @@ function mapInputContentBlock(block: Record<string, unknown>): MessagePart {
   case 'input_text':
     return { type: 'text', content: String(block.text ?? '') };
   case 'input_image':
-    return { type: 'image' as string, modality: 'image', ...stripBinaryFields(block) } as MessagePart;
+    return { type: 'blob', modality: 'image', ...stripBinaryFields(block) } as MessagePart;
   case 'input_file':
     return {
       type: 'file' as string,

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -5,8 +5,8 @@
 import { SpanStatusCode } from '@opentelemetry/api';
 import {
   OpenTelemetryConstants,
-  truncateValue,
   serializeMessages,
+  safeSerializeToJson,
   A365_MESSAGE_SCHEMA_VERSION,
   MessageRole,
   InputMessages,
@@ -23,9 +23,9 @@ import { Span as AgentsSpan, SpanData } from '@openai/agents-core/dist/tracing/s
  */
 export function safeJsonDumps(obj: unknown): string {
   try {
-    return truncateValue(JSON.stringify(obj));
+    return JSON.stringify(obj);
   } catch {
-    return truncateValue(String(obj));
+    return String(obj);
   }
 }
 
@@ -129,14 +129,18 @@ export function getAttributesFromFunctionSpanData(data: SpanData): Record<string
     attributes['gen_ai.tool.name'] = funcData.name;
   }
 
-  if (funcData.input) {
-    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] =
-      typeof funcData.input === 'string' ? truncateValue(funcData.input) : safeJsonDumps(funcData.input);
+  if (funcData.input != null) {
+    attributes[Constants.GEN_AI_REQUEST_CONTENT_KEY] = safeSerializeToJson(
+      typeof funcData.input === 'object' ? funcData.input as Record<string, unknown> : String(funcData.input),
+      'arguments'
+    );
   }
 
   if (funcData.output !== undefined && funcData.output !== null) {
-    const output = typeof funcData.output === 'object' ? safeJsonDumps(funcData.output) : truncateValue(String(funcData.output));
-    attributes[Constants.GEN_AI_RESPONSE_CONTENT_KEY] = output;
+    attributes[Constants.GEN_AI_RESPONSE_CONTENT_KEY] = safeSerializeToJson(
+      typeof funcData.output === 'object' ? funcData.output as Record<string, unknown> : String(funcData.output),
+      'result'
+    );
   }
 
   return attributes;

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -11,6 +11,7 @@ import {
   MessageRole,
   InputMessages,
   OutputMessages,
+  MAX_SPAN_SIZE_BYTES,
 } from '@microsoft/agents-a365-observability';
 import type { ChatMessage, OutputMessage, MessagePart } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
@@ -291,7 +292,7 @@ function stripBinaryFields(block: Record<string, unknown>): Record<string, unkno
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(block)) {
     if (key === 'type') continue;
-    if (typeof value === 'string' && value.length > 1024) {
+    if (typeof value === 'string' && value.length > MAX_SPAN_SIZE_BYTES) {
       result[key] = '[truncated]';
     } else {
       result[key] = value;

--- a/packages/agents-a365-observability/src/index.ts
+++ b/packages/agents-a365-observability/src/index.ts
@@ -86,7 +86,7 @@ export { truncateValue, MAX_ATTRIBUTE_LENGTH, safeSerializeToJson } from './trac
 export { serializeMessages, normalizeInputMessages, normalizeOutputMessages } from './tracing/message-utils';
 
 // Exporter utilities
-export { isPerRequestExportEnabled } from './tracing/exporter/utils';
+export { isPerRequestExportEnabled, MAX_SPAN_SIZE_BYTES } from './tracing/exporter/utils';
 
 // Configuration
 export * from './configuration';

--- a/packages/agents-a365-observability/src/index.ts
+++ b/packages/agents-a365-observability/src/index.ts
@@ -80,7 +80,7 @@ export { InferenceScope } from './tracing/scopes/InferenceScope';
 export { OutputScope } from './tracing/scopes/OutputScope';
 export { logger, setLogger, getLogger, resetLogger, formatError } from './utils/logging';
 export type { ILogger } from './utils/logging';
-export { truncateValue, MAX_ATTRIBUTE_LENGTH } from './tracing/util';
+export { truncateValue, MAX_ATTRIBUTE_LENGTH, safeSerializeToJson } from './tracing/util';
 
 // Message utilities
 export { serializeMessages, normalizeInputMessages, normalizeOutputMessages } from './tracing/message-utils';

--- a/packages/agents-a365-observability/src/index.ts
+++ b/packages/agents-a365-observability/src/index.ts
@@ -82,6 +82,9 @@ export { logger, setLogger, getLogger, resetLogger, formatError } from './utils/
 export type { ILogger } from './utils/logging';
 export { truncateValue, MAX_ATTRIBUTE_LENGTH } from './tracing/util';
 
+// Message utilities
+export { serializeMessages, normalizeInputMessages, normalizeOutputMessages } from './tracing/message-utils';
+
 // Exporter utilities
 export { isPerRequestExportEnabled } from './tracing/exporter/utils';
 

--- a/tests/observability/extension/helpers/message-schema-validator.ts
+++ b/tests/observability/extension/helpers/message-schema-validator.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+function validateMessageEnvelope(value: unknown): Record<string, unknown> {
+  // Attributes are stored as JSON strings; parse and validate the common envelope.
+  expect(typeof value).toBe('string');
+  const parsed = JSON.parse(value as string);
+  expect(parsed).toHaveProperty('version', '0.1.0');
+  expect(parsed.messages).toEqual(expect.arrayContaining([expect.anything()]));
+  return parsed;
+}
+
+function validateMessagePart(part: Record<string, unknown>): void {
+  // Validate required fields and type-specific shape for each message part.
+  expect(typeof part.type).toBe('string');
+  expect((part.type as string).length).toBeGreaterThan(0);
+
+  const type = part.type as string;
+  if (type === 'text' || type === 'reasoning') {
+    expect(typeof part.content).toBe('string');
+  } else if (type === 'tool_call') {
+    expect(typeof part.name).toBe('string');
+    if (part.id !== undefined) expect(typeof part.id).toBe('string');
+  } else if (type === 'tool_call_response') {
+    if (part.id !== undefined) expect(typeof part.id).toBe('string');
+  } else if (type === 'blob' || type === 'file' || type === 'uri') {
+    expect(part).toHaveProperty('modality');
+  }
+}
+
+export function expectValidInputMessages(value: unknown): void {
+  // Input messages must have a role and at least one valid part.
+  const parsed = validateMessageEnvelope(value);
+  for (const msg of parsed.messages as Array<Record<string, unknown>>) {
+    expect(typeof msg.role).toBe('string');
+    const parts = msg.parts as Array<Record<string, unknown>>;
+    expect(parts.length).toBeGreaterThan(0);
+    parts.forEach(validateMessagePart);
+  }
+}
+
+export function expectValidOutputMessages(value: unknown): void {
+  // Output messages follow the same structure, with optional finish_reason.
+  const parsed = validateMessageEnvelope(value);
+  for (const msg of parsed.messages as Array<Record<string, unknown>>) {
+    expect(typeof msg.role).toBe('string');
+    const parts = msg.parts as Array<Record<string, unknown>>;
+    expect(parts.length).toBeGreaterThan(0);
+    parts.forEach(validateMessagePart);
+    if (msg.finish_reason !== undefined) {
+      expect(typeof msg.finish_reason).toBe('string');
+    }
+  }
+}
+
+export function getSpanAttribute(mockSpan: { setAttribute: jest.Mock }, key: string): unknown {
+  // Helper to read a specific attribute from a mocked span.
+  const match = mockSpan.setAttribute.mock.calls.find(([k]: [string, unknown]) => k === key);
+  return match ? match[1] : undefined;
+}
+
+export function getAttrFromArray(attrs: Array<[string, unknown]>, key: string): unknown {
+  // Helper to read a key from an array of [key, value] tuples.
+  const entry = attrs.find(([k]) => k === key);
+  return entry ? entry[1] : undefined;
+}

--- a/tests/observability/extension/helpers/message-schema-validator.ts
+++ b/tests/observability/extension/helpers/message-schema-validator.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { expect } from '@jest/globals';
+
 function validateMessageEnvelope(value: unknown): Record<string, unknown> {
   // Attributes are stored as JSON strings; parse and validate the common envelope.
   expect(typeof value).toBe('string');

--- a/tests/observability/extension/langchain/LangChainMessageContract.test.ts
+++ b/tests/observability/extension/langchain/LangChainMessageContract.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { HumanMessage, AIMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import { Run } from "@langchain/core/tracers/base";
+import { Span } from "@opentelemetry/api";
+import { OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
+import * as Utils from "../../../../packages/agents-a365-observability-extensions-langchain/src/Utils";
+import { expectValidInputMessages, expectValidOutputMessages, getSpanAttribute } from "../helpers/message-schema-validator";
+
+describe("LangChain Message Contract Tests", () => {
+  let mockSpan: { setAttribute: jest.Mock; setStatus: jest.Mock; end: jest.Mock; recordException: jest.Mock };
+
+  beforeEach(() => {
+    mockSpan = {
+      setAttribute: jest.fn(),
+      setStatus: jest.fn(),
+      end: jest.fn(),
+      recordException: jest.fn(),
+    };
+  });
+
+  function getInputAttr(): string {
+    const value = getSpanAttribute(mockSpan, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
+    expect(value).toBeDefined();
+    return value as string;
+  }
+
+  function getOutputAttr(): string {
+    const value = getSpanAttribute(mockSpan, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
+    expect(value).toBeDefined();
+    return value as string;
+  }
+
+  function setInput(messages: unknown[]): void {
+    const run: Partial<Run> = { run_type: "llm", inputs: { messages: [messages] } };
+    Utils.setInputMessagesAttribute(run as Run, mockSpan as unknown as Span);
+  }
+
+  describe("Input messages from real LangChain types", () => {
+    it("should map a full conversation with all message types", () => {
+      setInput([
+        new SystemMessage("You are a weather assistant."),
+        new HumanMessage("What's the weather in Seattle?"),
+        new AIMessage({
+          content: "Let me check.",
+          tool_calls: [{ name: "get_weather", args: { city: "Seattle" }, id: "call_1" }],
+        }),
+        new ToolMessage({ content: "Rainy, 45°F", tool_call_id: "call_1" }),
+      ]);
+
+      const value = getInputAttr();
+      expectValidInputMessages(value);
+
+      const parsed = JSON.parse(value);
+      const roles = parsed.messages.map((m: Record<string, unknown>) => m.role);
+      expect(roles).toEqual(["system", "user", "assistant", "tool"]);
+
+      expect(parsed.messages[0].parts[0].content).toBe("You are a weather assistant.");
+      expect(parsed.messages[1].parts[0].content).toBe("What's the weather in Seattle?");
+
+      const aiParts = parsed.messages[2].parts;
+      expect(aiParts.find((p: Record<string, unknown>) => p.type === "text").content).toBe("Let me check.");
+      const toolCallPart = aiParts.find((p: Record<string, unknown>) => p.type === "tool_call");
+      expect(toolCallPart.name).toBe("get_weather");
+      expect(toolCallPart.id).toBe("call_1");
+
+      expect(parsed.messages[3].parts[0].content).toBe("Rainy, 45°F");
+    });
+  });
+
+  describe("Output messages from real LangChain types", () => {
+    it("should map AIMessage text output via generations", () => {
+      const run: Partial<Run> = {
+        run_type: "llm",
+        outputs: { generations: [[{ text: "Hello!", message: new AIMessage("Hello!") }]] },
+      };
+      Utils.setOutputMessagesAttribute(run as Run, mockSpan as unknown as Span);
+
+      const value = getOutputAttr();
+      expectValidOutputMessages(value);
+
+      const parsed = JSON.parse(value);
+      expect(parsed.messages[0].role).toBe("assistant");
+      expect(parsed.messages[0].parts[0].content).toBe("Hello!");
+    });
+
+    it("should map AIMessage with tool_calls in output via generations", () => {
+      const aiMsg = new AIMessage({
+        content: "",
+        tool_calls: [{ name: "search", args: { query: "weather" }, id: "call_456" }],
+      });
+      const run: Partial<Run> = {
+        run_type: "llm",
+        outputs: { generations: [[{ text: "", message: aiMsg }]] },
+      };
+      Utils.setOutputMessagesAttribute(run as Run, mockSpan as unknown as Span);
+
+      const value = getOutputAttr();
+      expectValidOutputMessages(value);
+
+      const toolPart = JSON.parse(value).messages[0].parts.find((p: Record<string, unknown>) => p.type === "tool_call");
+      expect(toolPart.name).toBe("search");
+      expect(toolPart.id).toBe("call_456");
+    });
+
+    it("should map direct output messages array (LangGraph path)", () => {
+      const run: Partial<Run> = {
+        run_type: "chain",
+        serialized: { id: ["langgraph", "graph", "CompiledStateGraph"] },
+        outputs: { messages: [new AIMessage("Task complete.")] },
+      };
+      Utils.setOutputMessagesAttribute(run as Run, mockSpan as unknown as Span);
+
+      const value = getOutputAttr();
+      expectValidOutputMessages(value);
+    });
+  });
+});

--- a/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
+++ b/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
@@ -5,6 +5,7 @@ import { Run } from "@langchain/core/tracers/base";
 import { Span } from "@opentelemetry/api";
 import { OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
 import * as Utils from "../../../../packages/agents-a365-observability-extensions-langchain/src/Utils";
+import { expectValidInputMessages, expectValidOutputMessages, getSpanAttribute } from "../helpers/message-schema-validator";
 
 describe("LangChain Observability - InvokeAgentScope Attributes", () => {
   let mockSpan: Partial<Span>;
@@ -42,9 +43,12 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       Utils.setInputMessagesAttribute(run as Run, mockSpan as Span);
 
+      const inputValue = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
+      expectValidInputMessages(inputValue);
+
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-        JSON.stringify(["hi"])
+        JSON.stringify({"version":"0.1.0","messages":[{"role":"user","parts":[{"type":"text","content":"hi"}]}]})
       );
     });
 
@@ -64,9 +68,12 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       Utils.setInputMessagesAttribute(run as Run, mockSpan as Span);
 
+      const inputValue = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
+      expectValidInputMessages(inputValue);
+
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-        JSON.stringify(["hello agent"])
+        JSON.stringify({"version":"0.1.0","messages":[{"role":"user","parts":[{"type":"text","content":"hello agent"}]}]})
       );
     });
 
@@ -86,9 +93,12 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       Utils.setOutputMessagesAttribute(run as Run, mockSpan as Span);
 
+      const outputValue = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
+      expectValidOutputMessages(outputValue);
+
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-        JSON.stringify(["Hello! How can I assist you today?"])
+        JSON.stringify({"version":"0.1.0","messages":[{"role":"assistant","parts":[{"type":"text","content":"Hello! How can I assist you today?"}]}]})
       );
     });
 
@@ -177,7 +187,33 @@ describe("LangChain Observability - ExecuteToolScope Attributes", () => {
       );
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY,
-        JSON.stringify("The weather in Seattle is currently rainy with a temperature of 39°C.")
+        "The weather in Seattle is currently rainy with a temperature of 39°C."
+      );
+    });
+
+    it("should extract tool result from v1 plain string output", () => {
+      const run: Partial<Run> = {
+        run_type: "tool",
+        name: "get_weather",
+        serialized: { name: "get_weather" },
+        inputs: {
+          input: '{"city": "Seattle"}',
+          tool_call_id: "call_v1_abc123",
+        },
+        outputs: {
+          output: "Sunny, 25°C in Seattle.",
+        },
+      };
+
+      Utils.setToolAttributes(run as Run, mockSpan as Span);
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY,
+        "Sunny, 25°C in Seattle."
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_TOOL_CALL_ID_KEY,
+        "call_v1_abc123"
       );
     });
   });

--- a/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
+++ b/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
@@ -410,5 +410,150 @@ describe("LangChain Observability - InferenceScope Attributes", () => {
         "You are a code generator"
       );
     });
+
+    it("should extract system instructions from v1 constructor format", () => {
+      const run: Partial<Run> = {
+        inputs: {
+          messages: [[
+            {
+              lc: 1,
+              type: "constructor",
+              id: ["langchain_core", "messages", "SystemMessage"],
+              kwargs: { content: "v1 system prompt" },
+            },
+            {
+              lc: 1,
+              type: "constructor",
+              id: ["langchain_core", "messages", "HumanMessage"],
+              kwargs: { content: "user input" },
+            },
+          ]],
+        },
+      };
+
+      Utils.setSystemInstructionsAttribute(run as Run, mockSpan as Span);
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_SYSTEM_INSTRUCTIONS_KEY,
+        "v1 system prompt"
+      );
+    });
+
+    it("should extract tokens from tokenUsage shape (promptTokens/completionTokens)", () => {
+      const run: Partial<Run> = {
+        outputs: {
+          generations: [[{
+            message: {
+              kwargs: {
+                response_metadata: {
+                  tokenUsage: {
+                    promptTokens: 100,
+                    completionTokens: 50,
+                    totalTokens: 150,
+                  },
+                },
+              },
+            },
+          }]],
+        },
+      };
+
+      Utils.setTokenAttributes(run as Run, mockSpan as Span);
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY,
+        100
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY,
+        50
+      );
+    });
+  });
+});
+
+describe("LangChain Observability - v1 Format Coverage", () => {
+  let mockSpan: Partial<Span>;
+
+  beforeEach(() => {
+    mockSpan = { setAttribute: jest.fn() };
+  });
+
+  it("should extract input content from v1 constructor format", () => {
+    const run: Partial<Run> = {
+      run_type: "llm",
+      inputs: {
+        messages: [[
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: { content: "v1 format message" },
+          },
+        ]],
+      },
+    };
+
+    Utils.setInputMessagesAttribute(run as Run, mockSpan as Span);
+
+    const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
+    expectValidInputMessages(value);
+    const parsed = JSON.parse(value as string);
+    expect(parsed.messages[0].parts[0].content).toBe("v1 format message");
+  });
+
+  it("should extract output content from v1 AIMessage constructor format", () => {
+    const run: Partial<Run> = {
+      run_type: "llm",
+      outputs: {
+        generations: [[{
+          message: {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "AIMessage"],
+            kwargs: { content: "v1 AI response", tool_calls: [] },
+          },
+        }]],
+      },
+    };
+
+    Utils.setOutputMessagesAttribute(run as Run, mockSpan as Span);
+
+    const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
+    expectValidOutputMessages(value);
+    const parsed = JSON.parse(value as string);
+    expect(parsed.messages[0].role).toBe("assistant");
+    expect(parsed.messages[0].parts[0].content).toBe("v1 AI response");
+  });
+
+  it("should not set input attribute when inputs.messages is missing", () => {
+    const run: Partial<Run> = { inputs: { other_key: "value" } };
+    Utils.setInputMessagesAttribute(run as Run, mockSpan as Span);
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
+      expect.anything()
+    );
+  });
+
+  it("should filter out non-AI messages from agent scope outputs", () => {
+    const run: Partial<Run> = {
+      run_type: "chain",
+      serialized: { id: ["langgraph", "graph", "CompiledStateGraph"] },
+      outputs: {
+        messages: [
+          { role: "user", content: "user message in output" },
+          { role: "system", content: "system in output" },
+          { role: "assistant", content: "ai response" },
+        ],
+      },
+    };
+
+    Utils.setOutputMessagesAttribute(run as Run, mockSpan as Span);
+
+    const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
+    const parsed = JSON.parse(value as string);
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0].role).toBe("assistant");
+    expect(parsed.messages[0].parts[0].content).toBe("ai response");
   });
 });

--- a/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
+++ b/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
@@ -187,7 +187,12 @@ describe("LangChain Observability - ExecuteToolScope Attributes", () => {
       );
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY,
-        "The weather in Seattle is currently rainy with a temperature of 39°C."
+        '{"result":"The weather in Seattle is currently rainy with a temperature of 39°C."}'
+      );
+      // Tool args: string input is already valid JSON, passed through by safeSerializeToJson
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY,
+        '{"city": "Seattle"}'
       );
     });
 
@@ -209,13 +214,18 @@ describe("LangChain Observability - ExecuteToolScope Attributes", () => {
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY,
-        "Sunny, 25°C in Seattle."
+        '{"result":"Sunny, 25°C in Seattle."}'
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY,
+        '{"city": "Seattle"}'
       );
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_TOOL_CALL_ID_KEY,
         "call_v1_abc123"
       );
     });
+
   });
 });
 

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -35,7 +35,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     let processor: OpenAIAgentsTraceProcessor;
 
     beforeEach(() => {
-      processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      processor = new OpenAIAgentsTraceProcessor(tracer, {});
     });
 
     afterEach(async () => {
@@ -480,8 +480,36 @@ describe('OpenAIAgentsTraceProcessor', () => {
       tracerSpy.mockRestore();
     });
 
+    it('should record tool arguments, result, and type on function span', async () => {
+      const processor = new OpenAIAgentsTraceProcessor(tracer);
+      const traceData = { traceId: 'trace-func-args', name: 'Agent' } as any;
+      await processor.onTraceStart(traceData);
+
+      const funcSpan = {
+        spanId: 'func-args-1',
+        traceId: 'trace-func-args',
+        startedAt: new Date().toISOString(),
+        spanData: {
+          type: 'function' as const,
+          name: 'get_weather',
+          input: { city: 'Seattle' },
+          output: 'Sunny, 25°C',
+        },
+      } as any;
+
+      await processor.onSpanStart(funcSpan);
+      await processor.onSpanEnd(funcSpan);
+
+      const mock = spansByName['get_weather'];
+      const attrs = mock._attrs as Array<[string, unknown]>;
+
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY)?.[1]).toBe('{"city":"Seattle"}');
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY)?.[1]).toBe('{"result":"Sunny, 25°C"}');
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY)?.[1]).toBe('function');
+    });
+
     it('does not record GEN_AI_INPUT_MESSAGES when disabled', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { suppressInvokeAgentInput: true, isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, { suppressInvokeAgentInput: true });
       const traceData = { traceId: 'trace-suppress', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -505,7 +533,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('records GEN_AI_INPUT_MESSAGES when content recording is enabled', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-allow', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -529,7 +557,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('suppresses input on response spans when disabled', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { suppressInvokeAgentInput: true, isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, { suppressInvokeAgentInput: true });
       const traceData = { traceId: 'trace-resp', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -553,7 +581,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('records structured InputMessages when only assistant messages are present', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-assistant-only', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -594,7 +622,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
       expect(parsed.messages[0].parts[0]).toEqual({ type: 'text', content: 'Assistant reply' });
     });
     it('records structured InputMessages for array _input on response spans', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-array-input', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -631,7 +659,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('parses stringified array _input and records all messages in structured format', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-array-input-string', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -672,7 +700,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('records structured InputMessages for array input with non standard schema on response spans', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-array-input', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
       const inputArray = [
@@ -707,7 +735,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('records GEN_AI_OUTPUT_MESSAGES in versioned envelope when output is a string', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-output-string', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -736,7 +764,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     it('records structured OutputMessages when output is structured', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       const traceData = { traceId: 'trace-output-structured', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
 
@@ -780,70 +808,6 @@ describe('OpenAIAgentsTraceProcessor', () => {
         { type: 'text', content: 'Hello user 1' },
         { type: 'text', content: 'Hello user 2' },
       ]);
-    });
-
-    it('suppresses all content attributes when isContentRecordingEnabled is false', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer);
-      const traceData = { traceId: 'trace-no-content', name: 'Agent' } as any;
-      await processor.onTraceStart(traceData);
-
-      // Generation span with input/output
-      const genSpan = {
-        spanId: 'gen-no-content',
-        traceId: 'trace-no-content',
-        startedAt: new Date().toISOString(),
-        spanData: {
-          type: 'generation' as const,
-          model: 'gpt-4',
-          input: [{ role: 'user', content: 'secret prompt' }],
-          output: { id: 'resp-1', choices: [{ text: 'secret response' }] },
-        },
-      } as any;
-
-      await processor.onSpanStart(genSpan);
-      await processor.onSpanEnd(genSpan);
-
-      const mock = spansByName['generation'];
-      const attrs = mock._attrs as Array<[string, unknown]>;
-      const contentKeys = attrs.filter(([k]) =>
-        k === OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY ||
-        k === OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY
-      );
-      expect(contentKeys).toHaveLength(0);
-
-      // Model attribute should still be present (non-content)
-      const modelAttr = attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY);
-      expect(modelAttr).toBeDefined();
-    });
-
-    it('suppresses content on response span when isContentRecordingEnabled is false', async () => {
-      const processor = new OpenAIAgentsTraceProcessor(tracer);
-      const traceData = { traceId: 'trace-resp-nc', name: 'Agent' } as any;
-      await processor.onTraceStart(traceData);
-
-      const respSpan = {
-        spanId: 'resp-nc',
-        traceId: 'trace-resp-nc',
-        startedAt: new Date().toISOString(),
-        spanData: {
-          type: 'response' as const,
-          _input: [{ role: 'user', content: 'secret input' }],
-          _response: {
-            model: 'gpt-4',
-            output: [{ role: 'assistant', content: [{ type: 'output_text', text: 'secret output' }] }],
-          },
-        },
-      } as any;
-
-      await processor.onSpanStart(respSpan);
-      await processor.onSpanEnd(respSpan);
-
-      const mock = spansByName['response'];
-      const attrs = mock._attrs as Array<[string, unknown]>;
-      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY)).toBeUndefined();
-      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY)).toBeUndefined();
-      // Model should still be present
-      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY)).toBeDefined();
     });
 
   });

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -13,6 +13,7 @@ import { OpenTelemetryConstants } from '@microsoft/agents-a365-observability';
 import { OpenAIAgentsTraceProcessor } from '@microsoft/agents-a365-observability-extensions-openai';
 import { ObservabilityManager } from '@microsoft/agents-a365-observability';
 import { trace } from '@opentelemetry/api';
+import { expectValidInputMessages, expectValidOutputMessages, getAttrFromArray } from '../helpers/message-schema-validator';
 
 describe('OpenAIAgentsTraceProcessor', () => {
   let tracer: Tracer;
@@ -551,7 +552,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
       expect(keys).not.toContain(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
     });
 
-    it('records full array JSON when only assistant messages are present', async () => {
+    it('records structured InputMessages when only assistant messages are present', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-assistant-only', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -583,11 +584,16 @@ describe('OpenAIAgentsTraceProcessor', () => {
       const entry = attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
       expect(entry).toBeDefined();
 
+      expectValidInputMessages(entry![1]);
+
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed).toEqual(inputArray);
+      expect(parsed.version).toBe('0.1.0');
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0].role).toBe('assistant');
+      expect(parsed.messages[0].parts[0]).toEqual({ type: 'text', content: 'Assistant reply' });
     });
-    it('records user text content for array _input on response spans', async () => {
+    it('records structured InputMessages for array _input on response spans', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-array-input', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -617,10 +623,14 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed).toEqual(['Hello user 1', 'Hello user 2']);
+      expect(parsed.version).toBe('0.1.0');
+      expect(parsed.messages).toHaveLength(2);
+      expectValidInputMessages(entry![1]);
+      expect(parsed.messages[0]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 1' }] });
+      expect(parsed.messages[1]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 2' }] });
     });
 
-    it('parses stringified array _input and records only user text content', async () => {
+    it('parses stringified array _input and records all messages in structured format', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-array-input-string', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -653,10 +663,15 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed).toEqual(['Hello user 1', 'Hello user 2']);
+      expect(parsed.version).toBe('0.1.0');
+      expect(parsed.messages).toHaveLength(3);
+      expectValidInputMessages(entry![1]);
+      expect(parsed.messages[0].role).toBe('user');
+      expect(parsed.messages[1].role).toBe('user');
+      expect(parsed.messages[2].role).toBe('assistant');
     });
 
-    it('records [gen_ai.input.messages] attribute for array input with non standard schema on response spans', async () => {
+    it('records structured InputMessages for array input with non standard schema on response spans', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-array-input', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -671,7 +686,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
         spanData: {
           type: 'response' as const,
           name: 'ResponseArray',
-          _input:  inputArray,         
+          _input:  inputArray,
           _response: { model: 'gpt-4', output: 'ok' },
         },
       } as any;
@@ -686,7 +701,9 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed).toEqual(inputArray);
+      expect(parsed.version).toBe('0.1.0');
+      expect(parsed.messages).toBeDefined();
+      expect(parsed.messages.length).toBeGreaterThan(0);
     });
 
     it('records GEN_AI_OUTPUT_MESSAGES as plain string when output is a string', async () => {
@@ -716,7 +733,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
       expect(entry![1]).toBe('final answer');
     });
 
-    it('records GEN_AI_OUTPUT_MESSAGES as aggregated texts when output is structured', async () => {
+    it('records structured OutputMessages when output is structured', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-output-structured', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -753,7 +770,14 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed).toEqual(['Hello user 1', 'Hello user 2']);
+      expect(parsed.version).toBe('0.1.0');
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0].role).toBe('assistant');
+      expectValidOutputMessages(entry![1]);
+      expect(parsed.messages[0].parts).toEqual([
+        { type: 'text', content: 'Hello user 1' },
+        { type: 'text', content: 'Hello user 2' },
+      ]);
     });
 
     it('suppresses all content attributes when isContentRecordingEnabled is false', async () => {

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -706,7 +706,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
       expect(parsed.messages.length).toBeGreaterThan(0);
     });
 
-    it('records GEN_AI_OUTPUT_MESSAGES as plain string when output is a string', async () => {
+    it('records GEN_AI_OUTPUT_MESSAGES in versioned envelope when output is a string', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
       const traceData = { traceId: 'trace-output-string', name: 'Agent' } as any;
       await processor.onTraceStart(traceData);
@@ -730,7 +730,9 @@ describe('OpenAIAgentsTraceProcessor', () => {
       const attrs = respMock._attrs as Array<[string, unknown]>;
       const entry = attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
       expect(entry).toBeDefined();
-      expect(entry![1]).toBe('final answer');
+      expectValidOutputMessages(entry![1]);
+      const parsed = JSON.parse(entry![1] as string);
+      expect(parsed.messages[0].parts[0].content).toBe('final answer');
     });
 
     it('records structured OutputMessages when output is structured', async () => {
@@ -812,6 +814,36 @@ describe('OpenAIAgentsTraceProcessor', () => {
       // Model attribute should still be present (non-content)
       const modelAttr = attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY);
       expect(modelAttr).toBeDefined();
+    });
+
+    it('suppresses content on response span when isContentRecordingEnabled is false', async () => {
+      const processor = new OpenAIAgentsTraceProcessor(tracer);
+      const traceData = { traceId: 'trace-resp-nc', name: 'Agent' } as any;
+      await processor.onTraceStart(traceData);
+
+      const respSpan = {
+        spanId: 'resp-nc',
+        traceId: 'trace-resp-nc',
+        startedAt: new Date().toISOString(),
+        spanData: {
+          type: 'response' as const,
+          _input: [{ role: 'user', content: 'secret input' }],
+          _response: {
+            model: 'gpt-4',
+            output: [{ role: 'assistant', content: [{ type: 'output_text', text: 'secret output' }] }],
+          },
+        },
+      } as any;
+
+      await processor.onSpanStart(respSpan);
+      await processor.onSpanEnd(respSpan);
+
+      const mock = spansByName['response'];
+      const attrs = mock._attrs as Array<[string, unknown]>;
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY)).toBeUndefined();
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY)).toBeUndefined();
+      // Model should still be present
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY)).toBeDefined();
     });
 
   });

--- a/tests/observability/extension/openai/OpenAIMessageContract.test.ts
+++ b/tests/observability/extension/openai/OpenAIMessageContract.test.ts
@@ -124,7 +124,7 @@ describe('OpenAI Message Contract Tests', () => {
     });
 
     async function runResponseSpan(traceId: string, spanName: string, input: any[], responseOutput: any[]): Promise<Array<[string, unknown]>> {
-      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
       await processor.onTraceStart({ traceId, name: 'Agent' } as any);
       const span = {
         spanId: `sid-${spanName}`,

--- a/tests/observability/extension/openai/OpenAIMessageContract.test.ts
+++ b/tests/observability/extension/openai/OpenAIMessageContract.test.ts
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { Tracer, trace } from '@opentelemetry/api';
+import { OpenTelemetryConstants, ObservabilityManager, serializeMessages } from '@microsoft/agents-a365-observability';
+import { OpenAIAgentsTraceProcessor } from '@microsoft/agents-a365-observability-extensions-openai';
+import {
+  buildStructuredInputMessages,
+  buildStructuredOutputMessages,
+  wrapRawContentAsInputMessages,
+  wrapRawContentAsOutputMessages,
+} from '../../../../packages/agents-a365-observability-extensions-openai/src/Utils';
+import { expectValidInputMessages, expectValidOutputMessages, getAttrFromArray } from '../helpers/message-schema-validator';
+
+describe('OpenAI Message Contract Tests', () => {
+
+  describe('buildStructuredInputMessages', () => {
+    it('should produce valid InputMessages from a multi-role conversation', () => {
+      const result = buildStructuredInputMessages([
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Hi!' },
+        { role: 'assistant', content: 'Hello! How can I help?' },
+        { role: 'user', content: 'What is 2+2?' },
+      ]);
+      expectValidInputMessages(serializeMessages(result));
+      expect(result.messages.map(m => m.role)).toEqual(['system', 'user', 'assistant', 'user']);
+      expect(result.messages[0].parts[0]).toEqual({ type: 'text', content: 'You are a helpful assistant.' });
+    });
+
+    it('should handle array content blocks (input_text, input_image)', () => {
+      const result = buildStructuredInputMessages([{
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'Describe this image' },
+          { type: 'input_image', image: 'https://example.com/img.png' },
+        ],
+      }] as any);
+      expectValidInputMessages(serializeMessages(result));
+      expect(result.messages[0].parts).toHaveLength(2);
+      expect(result.messages[0].parts[0]).toEqual({ type: 'text', content: 'Describe this image' });
+    });
+  });
+
+  describe('buildStructuredOutputMessages', () => {
+    it('should handle text, tool_call, and reasoning content', () => {
+      const result = buildStructuredOutputMessages([{
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'The user asked about weather.' },
+          { type: 'output_text', text: 'Let me check.' },
+          { type: 'tool_call', name: 'get_weather', call_id: 'call_1', arguments: '{"city":"Seattle"}' },
+        ],
+      }]);
+      expectValidOutputMessages(serializeMessages(result));
+
+      expect(result.messages[0].parts).toHaveLength(3);
+      const toolPart = result.messages[0].parts.find(p => p.type === 'tool_call') as any;
+      expect(toolPart.name).toBe('get_weather');
+      expect(toolPart.id).toBe('call_1');
+      expect(result.messages[0].parts.find(p => p.type === 'reasoning')).toBeDefined();
+    });
+
+    it('should handle mixed output types including refusal', () => {
+      const result = buildStructuredOutputMessages([{
+        role: 'assistant',
+        content: [
+          { type: 'output_text', text: 'Here is the answer.' },
+          { type: 'refusal', refusal: 'I cannot help with that.' },
+        ],
+      }]);
+      expectValidOutputMessages(serializeMessages(result));
+      expect(result.messages[0].parts).toHaveLength(2);
+    });
+  });
+
+  describe('wrapRawContent', () => {
+    it.each([
+      ['string', 'Hello prompt'],
+      ['object', { complex: 'data', nested: [1, 2] }],
+    ])('should produce valid InputMessages from raw %s', (_label, raw) => {
+      expectValidInputMessages(serializeMessages(wrapRawContentAsInputMessages(raw)));
+    });
+
+    it.each([
+      ['string', 'Model response'],
+      ['object', { result: 'data' }],
+    ])('should produce valid OutputMessages from raw %s', (_label, raw) => {
+      expectValidOutputMessages(serializeMessages(wrapRawContentAsOutputMessages(raw)));
+    });
+  });
+
+  describe('End-to-end: response span with real-shaped data', () => {
+    let tracer: Tracer;
+    let spansByName: Record<string, any>;
+    let tracerSpy: jest.SpyInstance;
+
+    const createMockSpan = (name: string) => {
+      const attrs: Array<[string, unknown]> = [];
+      return {
+        setAttribute: jest.fn((k: string, v: unknown) => { attrs.push([k, v]); }),
+        updateName: jest.fn(),
+        setStatus: jest.fn(),
+        end: jest.fn(),
+        spanContext: jest.fn(() => ({ traceId: 'tid-' + name, spanId: 'sid-' + name })),
+        _attrs: attrs,
+      };
+    };
+
+    beforeEach(() => {
+      ObservabilityManager.start({ serviceName: 'contract-test', serviceVersion: '1.0.0' });
+      tracer = trace.getTracer('contract-test', '1.0.0');
+      spansByName = {};
+      tracerSpy = jest.spyOn(tracer as any, 'startSpan').mockImplementation((...args: unknown[]) => {
+        const s = createMockSpan(args[0] as string);
+        spansByName[args[0] as string] = s;
+        return s;
+      });
+    });
+
+    afterEach(async () => {
+      tracerSpy.mockRestore();
+      await ObservabilityManager.shutdown();
+    });
+
+    async function runResponseSpan(traceId: string, spanName: string, input: any[], responseOutput: any[]): Promise<Array<[string, unknown]>> {
+      const processor = new OpenAIAgentsTraceProcessor(tracer, { isContentRecordingEnabled: true });
+      await processor.onTraceStart({ traceId, name: 'Agent' } as any);
+      const span = {
+        spanId: `sid-${spanName}`,
+        traceId,
+        startedAt: new Date().toISOString(),
+        spanData: {
+          type: 'response' as const,
+          name: spanName,
+          _input: input,
+          _response: { model: 'gpt-4o', output: responseOutput },
+        },
+      } as any;
+      await processor.onSpanStart(span);
+      await processor.onSpanEnd(span);
+      await processor.shutdown();
+      return spansByName[spanName]._attrs;
+    }
+
+    it('should produce valid InputMessages and OutputMessages for text response', async () => {
+      const attrs = await runResponseSpan('t1', 'TextResponse',
+        [{ role: 'system', content: 'You are helpful.' }, { role: 'user', content: 'What is 2+2?' }],
+        [{ role: 'assistant', content: [{ type: 'output_text', text: 'The answer is 4.' }] }],
+      );
+
+      expectValidInputMessages(getAttrFromArray(attrs, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY));
+      expectValidOutputMessages(getAttrFromArray(attrs, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY));
+    });
+
+    it('should produce valid OutputMessages with tool_call in response', async () => {
+      const attrs = await runResponseSpan('t2', 'ToolResponse',
+        [{ role: 'user', content: 'Get weather in Seattle' }],
+        [{ role: 'assistant', content: [{ type: 'tool_call', name: 'get_weather', call_id: 'call_abc', arguments: '{"city":"Seattle"}' }] }],
+      );
+
+      const outputValue = getAttrFromArray(attrs, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
+      expectValidOutputMessages(outputValue);
+
+      const toolPart = JSON.parse(outputValue as string).messages[0].parts.find((p: any) => p.type === 'tool_call');
+      expect(toolPart.name).toBe('get_weather');
+      expect(toolPart.id).toBe('call_abc');
+      expect(toolPart.arguments).toEqual({ city: 'Seattle' });
+    });
+  });
+});

--- a/tests/observability/extension/openai/OpenAIMessageContract.test.ts
+++ b/tests/observability/extension/openai/OpenAIMessageContract.test.ts
@@ -168,4 +168,72 @@ describe('OpenAI Message Contract Tests', () => {
       expect(toolPart.arguments).toEqual({ city: 'Seattle' });
     });
   });
+
+  describe('Edge cases', () => {
+    it('should return empty messages array for empty input', () => {
+      const result = buildStructuredInputMessages([]);
+      expect(result.version).toBe('0.1.0');
+      expect(result.messages).toHaveLength(0);
+    });
+
+    it('should skip null/non-object entries in input array', () => {
+      const result = buildStructuredInputMessages([null as any, undefined as any, { role: 'user', content: 'valid' }]);
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].parts[0]).toEqual({ type: 'text', content: 'valid' });
+    });
+
+    it('should return empty messages array for empty output', () => {
+      const result = buildStructuredOutputMessages([]);
+      expect(result.messages).toHaveLength(0);
+    });
+
+    it('should map function_call content block to tool_call part', () => {
+      const result = buildStructuredOutputMessages([{
+        role: 'assistant',
+        content: [
+          { type: 'function_call', name: 'my_func', id: 'fc_1', arguments: '{"x":1}' },
+        ],
+      }]);
+      expect(result.messages[0].parts[0].type).toBe('tool_call');
+      const part = result.messages[0].parts[0] as any;
+      expect(part.name).toBe('my_func');
+      expect(part.id).toBe('fc_1');
+      expect(part.arguments).toEqual({ x: 1 });
+    });
+
+    it('should map input_file block with modality from mime_type', () => {
+      const result = buildStructuredInputMessages([{
+        role: 'user',
+        content: [
+          { type: 'input_file', mime_type: 'application/pdf', file_id: 'file_123' },
+        ],
+      }] as any);
+      expect(result.messages[0].parts[0].type).toBe('file');
+      expect((result.messages[0].parts[0] as any).modality).toBe('application');
+    });
+
+    it('should fall back to raw wrapper when tool_call arguments are malformed JSON', () => {
+      const result = buildStructuredOutputMessages([{
+        role: 'assistant',
+        content: [
+          { type: 'tool_call', name: 'get_weather', call_id: 'c1', arguments: 'not-json{{{' },
+        ],
+      }]);
+      const part = result.messages[0].parts[0] as any;
+      expect(part.type).toBe('tool_call');
+      expect(part.arguments).toEqual({ raw: 'not-json{{{' });
+    });
+
+    it('should produce a generic part for unknown input content block types', () => {
+      const result = buildStructuredInputMessages([{
+        role: 'user',
+        content: [
+          { type: 'future_block_type', some_field: 'value' },
+        ],
+      }] as any);
+      const part = result.messages[0].parts[0] as any;
+      expect(part.type).toBe('future_block_type');
+      expect(typeof part.content).toBe('string');
+    });
+  });
 });

--- a/tests/observability/integration/openai-agent-instrument.test.ts
+++ b/tests/observability/integration/openai-agent-instrument.test.ts
@@ -43,7 +43,6 @@ describe("OpenAI Trace Processor Integration Tests", () => {
       enabled: true,
       tracerName: TEST_INSTRUMENTATION_NAME,
       tracerVersion: TEST_INSTRUMENTATION_VERSION,
-      isContentRecordingEnabled: true,
     });
 
     // Start observability
@@ -349,7 +348,7 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         ).toBe('{"a":15,"b":27}');
         expect(
           toolSpan.attributes[OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY],
-        ).toBe("The sum of 15 and 27 is 42");
+        ).toBe('{"result":"The sum of 15 and 27 is 42"}');
 
         validateParentChildRelationship(toolSpan, agentSpan!);
 


### PR DESCRIPTION
## Summary
- Add auto-instrumented input/output message recording in OTEL gen-ai format (`version: "0.1.0"`) for both OpenAI and LangChain extensions — content attributes are recorded unconditionally (no opt-in gating)
- Fix LangChain v1 compatibility: tool results, tool call IDs, system instructions, token usage, model name, and message type detection now handle v1 (LangGraph) formats
- Add message-schema-validator test helper and contract test suites for both extensions
- Use shared `MAX_SPAN_SIZE_BYTES` constant for binary field truncation instead of hardcoded values

> **Note:** This PR is built on top of #228 (structured object support for tool call arguments/responses). It should be merged after #228.

## Changes

### OpenAI Extension
- `OpenAIAgentsTraceProcessor`: Auto-records structured `InputMessages`/`OutputMessages` on response, generation, and function spans; all string fallbacks now use versioned envelope
- `Utils.ts`: New `buildStructuredInputMessages()` and `buildStructuredOutputMessages()` for OTEL gen-ai schema conversion; removed unused `getAttributesFromInput`; uses `MAX_SPAN_SIZE_BYTES` for truncation

### LangChain Extension
- `LangChainTracer`: Content attributes are recorded unconditionally — removed `isContentRecordingEnabled` option
- `Utils.ts`: New structured message builders (`setInputMessagesAttribute`, `setOutputMessagesAttribute`); v1 fixes for `setToolAttributes`, `setSystemInstructionsAttribute`, `setTokenAttributes`, `getModel`, `getMessageType`

### Core
- Export new OTEL gen-ai message types and serialization utilities from `index.ts`
- Export `MAX_SPAN_SIZE_BYTES` from observability package

## Test plan
- [x] All 1206 unit tests pass (62 suites)
- [x] LangChain sample: validated spans with tool call flow (get_weather) — all attributes correct
- [x] OpenAI sample: validated spans with MCP tools + LLM response — all attributes correct
- [x] Code review findings (CRM-001 through CRM-013) addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
