### PR TITLE
Align auto-instrument spans with A365 schema  and integration tests refactor. 

### DIFF
--- a/jest.integration.config.cjs
+++ b/jest.integration.config.cjs
@@ -20,7 +20,6 @@ module.exports = {
     'ts-jest': {
       tsconfig: {
         module: 'commonjs',
-        moduleResolution: 'bundler',
         esModuleInterop: true,
       },
     },

--- a/jest.integration.config.cjs
+++ b/jest.integration.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
     'ts-jest': {
       tsconfig: {
         module: 'commonjs',
+        moduleResolution: 'bundler',
         esModuleInterop: true,
       },
     },

--- a/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
@@ -428,13 +428,14 @@ export function setSessionIdAttribute(run: Run, span: Span): void {
   const metadata = run.extra?.metadata as Record<string, unknown> | undefined;
   if (!metadata) return;
 
-  const sessionId =
-    metadata.session_id ??
-    metadata.conversation_id ??
-    metadata.thread_id;
-
-  if (typeof sessionId === "string" && sessionId.length > 0) {
+  const sessionId = metadata.session_id ?? metadata.thread_id;
+  if (isString(sessionId) && sessionId.length > 0) {
     span.setAttribute(OpenTelemetryConstants.SESSION_ID_KEY, sessionId);
+  }
+
+  const conversationId = metadata.conversation_id;
+  if (isString(conversationId) && conversationId.length > 0) {
+    span.setAttribute(OpenTelemetryConstants.GEN_AI_CONVERSATION_ID_KEY, conversationId);
   }
 }
 

--- a/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
@@ -52,12 +52,16 @@ export class LangChainTracer extends BaseTracer {
       : context.active();
 
     let spanName = run.name;
+    let kind: SpanKind = SpanKind.INTERNAL;
     if (operation === "invoke_agent") {
       spanName = `${operation} ${run.name}`;
+      kind = SpanKind.SERVER;
     } else if (operation === "execute_tool") {
       spanName = `${operation} ${run.name}`;
+      kind = SpanKind.CLIENT;
     } else if (operation === "chat") {
       spanName = `${operation} ${Utils.getModel(run) || run.name}`.trim();
+      kind = SpanKind.CLIENT;
     }
 
     if (this.runs.size >= LangChainTracer.MAX_RUNS) {
@@ -68,7 +72,7 @@ export class LangChainTracer extends BaseTracer {
 
     const startTime = run.start_time ?? Date.now();
     const span = this.tracer.startSpan(spanName, {
-      kind: SpanKind.INTERNAL,
+      kind,
       startTime,
       attributes: { [OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY]: "langchain" },
     }, activeContext);
@@ -107,7 +111,10 @@ export class LangChainTracer extends BaseTracer {
       if (run.error) {
         span.setStatus({ code: SpanStatusCode.ERROR });
         span.setAttribute(OpenTelemetryConstants.ERROR_MESSAGE_KEY, String(run.error));
-
+        const errorType = (run.error as { name?: string })?.name ?? (run.error as any)?.constructor?.name;
+        if (typeof errorType === "string" && errorType.length > 0) {
+          span.setAttribute(OpenTelemetryConstants.ERROR_TYPE_KEY, errorType);
+        }
       } else {
         span.setStatus({ code: SpanStatusCode.OK });
       }
@@ -115,6 +122,12 @@ export class LangChainTracer extends BaseTracer {
       // Set all attributes
       Utils.setOperationTypeAttribute(operation, span);
       Utils.setAgentAttributes(run, span);
+      if (operation === "invoke_agent") {
+        const callerName = this.findCallerAgentName(run);
+        if (callerName) {
+          span.setAttribute(OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY, callerName);
+        }
+      }
       Utils.setModelAttribute(run, span);
       Utils.setProviderNameAttribute(run, span);
       Utils.setSessionIdAttribute(run, span);
@@ -143,6 +156,18 @@ export class LangChainTracer extends BaseTracer {
     while (pid) {
       const entry = this.runs.get(pid);
       if (entry) return entry.span.spanContext();
+      pid = this.parentByRunId.get(pid);
+    }
+    return undefined;
+  }
+
+  private findCallerAgentName(run: Run): string | undefined {
+    let pid = run.parent_run_id;
+    while (pid) {
+      const entry = this.runs.get(pid);
+      if (entry && Utils.getOperationType(entry.run) === "invoke_agent") {
+        return entry.run.name;
+      }
       pid = this.parentByRunId.get(pid);
     }
     return undefined;

--- a/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/tracer.ts
@@ -111,7 +111,7 @@ export class LangChainTracer extends BaseTracer {
       if (run.error) {
         span.setStatus({ code: SpanStatusCode.ERROR });
         span.setAttribute(OpenTelemetryConstants.ERROR_MESSAGE_KEY, String(run.error));
-        const errorType = (run.error as { name?: string })?.name ?? (run.error as any)?.constructor?.name;
+        const errorType = (run.error as { name?: string })?.name ?? (run.error as { constructor?: { name?: string } })?.constructor?.name;
         if (typeof errorType === "string" && errorType.length > 0) {
           span.setAttribute(OpenTelemetryConstants.ERROR_TYPE_KEY, errorType);
         }

--- a/packages/agents-a365-observability-extensions-openai/src/Constants.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Constants.ts
@@ -29,8 +29,6 @@ export const GEN_AI_MESSAGE_TOOL_CALL_NAME = 'message_tool_name';
 export const GEN_AI_TOOL_JSON_SCHEMA = 'tool_json_schema';
 export const GEN_AI_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHED_READ = 'llm_token_count_prompt_details_cached_read';
 export const GEN_AI_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING = 'llm_token_count_completion_details_reasoning';
-export const GEN_AI_GRAPH_NODE_ID = 'graph_node_id';
-export const GEN_AI_GRAPH_NODE_PARENT_ID = 'graph_node_parent_id';
 
 export const GEN_AI_REQUEST_CONTENT_KEY = 'gen_ai.request.content';
 export const GEN_AI_RESPONSE_CONTENT_KEY = 'gen_ai.response.content';

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -31,6 +31,8 @@ type ContextToken = unknown;
 export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   private static readonly MAX_HANDOFFS_IN_FLIGHT = 1000;
   private static readonly MAX_SPANS_IN_FLIGHT = 10_000;
+  private static readonly SERVER_SPAN_TYPES = new Set(['agent']);
+  private static readonly CLIENT_SPAN_TYPES = new Set(['handoff', 'response', 'generation', 'function', 'mcp_tools']);
 
   private readonly tracer: OtelTracer;
   private readonly suppressInvokeAgentInput: boolean;
@@ -126,11 +128,9 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     const spanName = Utils.getSpanName(span);
 
     // SpanKind per OTel client/server semantics + A365 schema:
-    const SERVER_SPAN_TYPES = new Set(['agent']);
-    const CLIENT_SPAN_TYPES = new Set(['handoff', 'response', 'generation', 'function', 'mcp_tools']);
-    const kind = SERVER_SPAN_TYPES.has(spanType)
+    const kind = OpenAIAgentsTraceProcessor.SERVER_SPAN_TYPES.has(spanType)
       ? SpanKind.SERVER
-      : CLIENT_SPAN_TYPES.has(spanType)
+      : OpenAIAgentsTraceProcessor.CLIENT_SPAN_TYPES.has(spanType)
         ? SpanKind.CLIENT
         : undefined;
 
@@ -334,7 +334,9 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
 
     // Update span name with model
     const modelName = attrs[OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY];
-    otelSpan.updateName(`${InferenceOperationType.CHAT} ${modelName}`);
+    if (typeof modelName === 'string' && modelName.length > 0) {
+      otelSpan.updateName(`${InferenceOperationType.CHAT} ${modelName}`);
+    }
   }
 
   /**

--- a/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/OpenAIAgentsTraceProcessor.ts
@@ -7,7 +7,7 @@
  * Converts OpenAI Agents SDK spans to OpenTelemetry spans
  */
 
-import { context, trace as OtelTrace, Span as OtelSpan, Tracer as OtelTracer } from '@opentelemetry/api';
+import { context, trace as OtelTrace, Span as OtelSpan, Tracer as OtelTracer, SpanKind } from '@opentelemetry/api';
 import { OpenTelemetryConstants, InferenceOperationType, logger, serializeMessages } from '@microsoft/agents-a365-observability';
 import * as Constants from './Constants';
 import * as Utils from './Utils';
@@ -98,6 +98,14 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
       return;
     }
 
+    // Handoff spans are emitted as CLIENT-kind InvokeAgent spans (see processHandoffSpanData).
+    const spanType = spanData?.type as string | undefined;
+
+    // Skip span types we don't map to schema-defined operations.
+    if (!spanType || spanType === 'custom' || spanType === 'guardrail') {
+      return;
+    }
+
     if (this.otelSpans.size >= OpenAIAgentsTraceProcessor.MAX_SPANS_IN_FLIGHT) {
       logger.warn(`[OpenAIAgentsTraceProcessor] Max spans in flight (${OpenAIAgentsTraceProcessor.MAX_SPANS_IN_FLIGHT}) reached, skipping span`);
       return;
@@ -117,10 +125,20 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
 
     const spanName = Utils.getSpanName(span);
 
+    // SpanKind per OTel client/server semantics + A365 schema:
+    const SERVER_SPAN_TYPES = new Set(['agent']);
+    const CLIENT_SPAN_TYPES = new Set(['handoff', 'response', 'generation', 'function', 'mcp_tools']);
+    const kind = SERVER_SPAN_TYPES.has(spanType)
+      ? SpanKind.SERVER
+      : CLIENT_SPAN_TYPES.has(spanType)
+        ? SpanKind.CLIENT
+        : undefined;
+
     // Start OpenTelemetry span
     const otelSpan = this.tracer.startSpan(
       spanName,
       {
+        kind,
         startTime,
         attributes: {
           [OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]: Utils.getSpanKind(spanData),
@@ -182,6 +200,14 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     const endTime = endedAt ? new Date(endedAt).getTime() : undefined;
     const status = Utils.getSpanStatus(span);
     otelSpan.setStatus(status);
+    if (span.error) {
+      const errData = (span.error as { data?: Record<string, unknown>; name?: string }).data;
+      const errorType =
+        (typeof errData?.type === 'string' && errData.type) ||
+        (span.error as { name?: string }).name ||
+        'error';
+      otelSpan.setAttribute(OpenTelemetryConstants.ERROR_TYPE_KEY, errorType);
+    }
     if (endTime) {
       otelSpan.end(endTime);
     } else {
@@ -307,11 +333,8 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
     this.stampCustomParent(otelSpan, traceId);
 
     // Update span name with model
-    const operationName = attrs[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY];
     const modelName = attrs[OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY];
-    if (operationName && modelName) {
-      otelSpan.updateName(`${operationName} ${modelName}`);
-    }
+    otelSpan.updateName(`${InferenceOperationType.CHAT} ${modelName}`);
   }
 
   /**
@@ -358,13 +381,19 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   }
 
   /**
-   * Process handoff span data
+   * Process handoff span data. The handoff span is emitted as a CLIENT-kind
+   * Invoke Agent span representing the caller invoking the target agent.
+   * The from→to mapping is also recorded so the downstream agent (SERVER)
+   * span can back-reference the caller.
    */
-  private processHandoffSpanData(_otelSpan: OtelSpan, data: SpanData, traceId: string): void {
+  private processHandoffSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string): void {
     const handoffData = data as Record<string, unknown>;
-    if (handoffData.to_agent && handoffData.from_agent) {
-      const key = `${handoffData.to_agent}:${traceId}`;
-      this.reverseHandoffsDict.set(key, handoffData.from_agent as string);
+    const fromAgent = handoffData.from_agent as string | undefined;
+    const toAgent = handoffData.to_agent as string | undefined;
+
+    if (toAgent && fromAgent) {
+      const key = `${toAgent}:${traceId}`;
+      this.reverseHandoffsDict.set(key, fromAgent);
 
       // Cap the size
       while (this.reverseHandoffsDict.size > OpenAIAgentsTraceProcessor.MAX_HANDOFFS_IN_FLIGHT) {
@@ -374,6 +403,18 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
         }
       }
     }
+
+    otelSpan.setAttribute(
+      OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY,
+      OpenTelemetryConstants.INVOKE_AGENT_OPERATION_NAME
+    );
+    if (toAgent) {
+      otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY, toAgent);
+      otelSpan.updateName(`${OpenTelemetryConstants.INVOKE_AGENT_OPERATION_NAME} ${toAgent}`);
+    }
+    if (fromAgent) {
+      otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY, fromAgent);
+    }
   }
 
   /**
@@ -382,15 +423,15 @@ export class OpenAIAgentsTraceProcessor implements TracingProcessor {
   private processAgentSpanData(otelSpan: OtelSpan, data: SpanData, traceId: string): void {
     const agentData = data as Record<string, unknown>;
     if (agentData.name) {
-      otelSpan.setAttribute(Constants.GEN_AI_GRAPH_NODE_ID, agentData.name as string);
+      otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY, agentData.name as string);
       otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY, OpenTelemetryConstants.INVOKE_AGENT_OPERATION_NAME);
 
-      // Lookup parent node if exists
+      // Link back to the agent that handed off to this one (A2A caller semantics)
       const key = `${agentData.name}:${traceId}`;
       const parentNode = this.reverseHandoffsDict.get(key);
       if (parentNode) {
         this.reverseHandoffsDict.delete(key);
-        otelSpan.setAttribute(Constants.GEN_AI_GRAPH_NODE_PARENT_ID, parentNode);
+        otelSpan.setAttribute(OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY, parentNode);
       }
 
       // Update span name for agent

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -22,6 +22,41 @@ import { Span as AgentsSpan, SpanData } from '@openai/agents-core/dist/tracing/s
  * @param obj - The object to stringify
  * @returns JSON string representation or string conversion if JSON.stringify fails
  */
+/**
+ * Locate and normalize usage counts across OpenAI API shapes:
+ * - Responses API:    { input_tokens, output_tokens }
+ * - Chat Completions: { prompt_tokens, completion_tokens }
+ * Usage may live directly on the span data, on `.output`, or inside `.output[0]`.
+ */
+export function extractUsageTokens(data: Record<string, unknown>): { inputTokens?: number; outputTokens?: number } {
+      const candidates: Array<Record<string, unknown> | undefined> = [];
+      const direct = data.usage as Record<string, unknown> | undefined;
+      candidates.push(direct);
+      const output = data.output as unknown;
+      if (output && typeof output === 'object') {
+        if (Array.isArray(output)) {
+          const first = output[0];
+          if (first && typeof first === 'object') {
+            candidates.push((first as Record<string, unknown>).usage as Record<string, unknown> | undefined);
+          }
+        } else {
+          candidates.push((output as Record<string, unknown>).usage as Record<string, unknown> | undefined);
+        }
+      }
+      for (const usage of candidates) {
+        if (!usage) continue;
+        const inputTokens = usage.input_tokens ?? usage.prompt_tokens;
+        const outputTokens = usage.output_tokens ?? usage.completion_tokens;
+        if (typeof inputTokens === 'number' || typeof outputTokens === 'number') {
+          return {
+            inputTokens: typeof inputTokens === 'number' ? inputTokens : undefined,
+            outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
+          };
+        }
+      }
+      return {};
+  }
+
 export function safeJsonDumps(obj: unknown): string {
   try {
     return JSON.stringify(obj);
@@ -105,14 +140,12 @@ export function getAttributesFromGenerationSpanData(data: SpanData): Record<stri
     attributes[Constants.GEN_AI_RESPONSE_CONTENT_KEY] = serializeMessages(wrapRawContentAsOutputMessages(genData.output));
   }
 
-  if (genData.usage) {
-    const usage = genData.usage as Record<string, unknown>;
-    if (usage.input_tokens !== undefined) {
-      attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY] = usage.input_tokens;
-    }
-    if (usage.output_tokens !== undefined) {
-      attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY] = usage.output_tokens;
-    }
+  const genUsage = extractUsageTokens(genData);
+  if (genUsage.inputTokens !== undefined) {
+    attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY] = genUsage.inputTokens;
+  }
+  if (genUsage.outputTokens !== undefined) {
+    attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY] = genUsage.outputTokens;
   }
 
   return attributes;
@@ -173,14 +206,12 @@ export function getAttributesFromResponse(response: unknown): Record<string, unk
     attributes[OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY] = resp.model;
   }
 
-  if (resp.usage) {
-    const usage = resp.usage as Record<string, unknown>;
-    if (usage.input_tokens !== undefined) {
-      attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY] = usage.input_tokens;
-    }
-    if (usage.output_tokens !== undefined) {
-      attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY] = usage.output_tokens;
-    }
+  const respUsage = extractUsageTokens(resp);
+  if (respUsage.inputTokens !== undefined) {
+    attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY] = respUsage.inputTokens;
+  }
+  if (respUsage.outputTokens !== undefined) {
+    attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY] = respUsage.outputTokens;
   }
 
   return attributes;

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -18,45 +18,45 @@ import * as Constants from './Constants';
 import { Span as AgentsSpan, SpanData } from '@openai/agents-core/dist/tracing/spans';
 
 /**
- * Safely stringify an object to JSON
- * @param obj - The object to stringify
- * @returns JSON string representation or string conversion if JSON.stringify fails
- */
-/**
  * Locate and normalize usage counts across OpenAI API shapes:
  * - Responses API:    { input_tokens, output_tokens }
  * - Chat Completions: { prompt_tokens, completion_tokens }
  * Usage may live directly on the span data, on `.output`, or inside `.output[0]`.
  */
 export function extractUsageTokens(data: Record<string, unknown>): { inputTokens?: number; outputTokens?: number } {
-      const candidates: Array<Record<string, unknown> | undefined> = [];
-      const direct = data.usage as Record<string, unknown> | undefined;
-      candidates.push(direct);
-      const output = data.output as unknown;
-      if (output && typeof output === 'object') {
-        if (Array.isArray(output)) {
-          const first = output[0];
-          if (first && typeof first === 'object') {
-            candidates.push((first as Record<string, unknown>).usage as Record<string, unknown> | undefined);
-          }
-        } else {
-          candidates.push((output as Record<string, unknown>).usage as Record<string, unknown> | undefined);
-        }
+  const candidates: Array<Record<string, unknown> | undefined> = [];
+  const direct = data.usage as Record<string, unknown> | undefined;
+  candidates.push(direct);
+  const output = data.output as unknown;
+  if (output && typeof output === 'object') {
+    if (Array.isArray(output)) {
+      const first = output[0];
+      if (first && typeof first === 'object') {
+        candidates.push((first as Record<string, unknown>).usage as Record<string, unknown> | undefined);
       }
-      for (const usage of candidates) {
-        if (!usage) continue;
-        const inputTokens = usage.input_tokens ?? usage.prompt_tokens;
-        const outputTokens = usage.output_tokens ?? usage.completion_tokens;
-        if (typeof inputTokens === 'number' || typeof outputTokens === 'number') {
-          return {
-            inputTokens: typeof inputTokens === 'number' ? inputTokens : undefined,
-            outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
-          };
-        }
-      }
-      return {};
+    } else {
+      candidates.push((output as Record<string, unknown>).usage as Record<string, unknown> | undefined);
+    }
   }
+  for (const usage of candidates) {
+    if (!usage) continue;
+    const inputTokens = usage.input_tokens ?? usage.prompt_tokens;
+    const outputTokens = usage.output_tokens ?? usage.completion_tokens;
+    if (typeof inputTokens === 'number' || typeof outputTokens === 'number') {
+      return {
+        inputTokens: typeof inputTokens === 'number' ? inputTokens : undefined,
+        outputTokens: typeof outputTokens === 'number' ? outputTokens : undefined,
+      };
+    }
+  }
+  return {};
+}
 
+/**
+ * Safely stringify an object to JSON
+ * @param obj - The object to stringify
+ * @returns JSON string representation or string conversion if JSON.stringify fails
+ */
 export function safeJsonDumps(obj: unknown): string {
   try {
     return JSON.stringify(obj);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ catalogs:
       specifier: ^9.39.1
       version: 9.39.1
     '@langchain/core':
-      specifier: ^1.1.39
+      specifier: ^1.1.32
       version: 1.1.40
     '@langchain/langgraph':
       specifier: ^1.2.2
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^1.1.3
       version: 1.1.3
     '@langchain/openai':
-      specifier: ^1.4.4
-      version: 1.4.4
+      specifier: ^0.5.0
+      version: 0.5.18
     '@microsoft/agents-activity':
       specifier: ^1.3.1
       version: 1.3.1
@@ -717,7 +717,7 @@ importers:
         version: 1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 1.4.4(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)
+        version: 0.5.18(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)
       '@microsoft/agents-a365-observability':
         specifier: workspace:*
         version: link:../packages/agents-a365-observability
@@ -1420,11 +1420,11 @@ packages:
       '@langchain/core': ^1.0.0
       '@langchain/langgraph': ^1.0.0
 
-  '@langchain/openai@1.4.4':
-    resolution: {integrity: sha512-mRr/X5rvlwPj6cSXPxbL+CtOqYANO1/+CQ3Z+5t48kWnrlgPYOazmA+UAWvqQOuwJ6LaYn3SFrt43rR4lte/Ow==}
-    engines: {node: '>=20'}
+  '@langchain/openai@0.5.18':
+    resolution: {integrity: sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.39
+      '@langchain/core': '>=0.3.58 <0.4.0'
 
   '@microsoft/agents-activity@1.3.1':
     resolution: {integrity: sha512-4k44NrfEqXiSg49ofj8geV8ylPocqDLtZKKt0PFL9BvFV0n57X3y1s/fEbsf7Fkl3+P/R2XLyMB5atEGf/eRGg==}
@@ -3184,6 +3184,18 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^4.1.12
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openai@6.29.0:
     resolution: {integrity: sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==}
     hasBin: true
@@ -4613,11 +4625,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@langchain/openai@1.4.4(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)':
+  '@langchain/openai@0.5.18(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)':
     dependencies:
       '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       js-tiktoken: 1.0.21
-      openai: 6.34.0(ws@8.18.3)(zod@4.1.13)
+      openai: 5.23.2(ws@8.18.3)(zod@4.1.13)
       zod: 4.1.13
     transitivePeerDependencies:
       - ws
@@ -6743,6 +6755,11 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  openai@5.23.2(ws@8.18.3)(zod@4.1.13):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 4.1.13
+
   openai@6.29.0(ws@8.18.3)(zod@4.1.13):
     optionalDependencies:
       ws: 8.18.3
@@ -6752,6 +6769,7 @@ snapshots:
     optionalDependencies:
       ws: 8.18.3
       zod: 4.1.13
+    optional: true
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^9.39.1
       version: 9.39.1
     '@langchain/core':
-      specifier: ^1.1.32
-      version: 1.1.32
+      specifier: ^1.1.39
+      version: 1.1.40
     '@langchain/langgraph':
       specifier: ^1.2.2
       version: 1.2.2
@@ -28,8 +28,8 @@ catalogs:
       specifier: ^1.1.3
       version: 1.1.3
     '@langchain/openai':
-      specifier: ^0.5.0
-      version: 0.5.18
+      specifier: ^1.4.4
+      version: 1.4.4
     '@microsoft/agents-activity':
       specifier: ^1.3.1
       version: 1.3.1
@@ -293,7 +293,7 @@ importers:
         version: 9.39.1
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+        version: 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
@@ -586,13 +586,13 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+        version: 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       '@langchain/langgraph':
         specifier: 'catalog:'
-        version: 1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+        version: 1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
       '@langchain/mcp-adapters':
         specifier: 'catalog:'
-        version: 1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@langchain/langgraph@1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))
+        version: 1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@langchain/langgraph@1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))
       '@microsoft/agents-a365-runtime':
         specifier: workspace:*
         version: link:../agents-a365-runtime
@@ -607,7 +607,7 @@ importers:
         version: 4.11.7
       langchain:
         specifier: 'catalog:'
-        version: 1.2.32(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@4.1.13))
+        version: 1.2.32(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@4.1.13))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -711,13 +711,13 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: 'catalog:'
-        version: 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+        version: 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       '@langchain/langgraph':
         specifier: 'catalog:'
-        version: 1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+        version: 1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
       '@langchain/openai':
         specifier: 'catalog:'
-        version: 0.5.18(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)
+        version: 1.4.4(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)
       '@microsoft/agents-a365-observability':
         specifier: workspace:*
         version: link:../packages/agents-a365-observability
@@ -1369,8 +1369,8 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@langchain/core@1.1.32':
-    resolution: {integrity: sha512-ZZNiER5tceFXqZOghfrxNHzM60gcQL5XK/8Ow5+o4OuKHrP1p/RUQBDM9Y1nddi/VmKQj+ncaXXM5KovXTEGGQ==}
+  '@langchain/core@1.1.40':
+    resolution: {integrity: sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==}
     engines: {node: '>=20'}
 
   '@langchain/langgraph-checkpoint@1.0.0':
@@ -1420,11 +1420,11 @@ packages:
       '@langchain/core': ^1.0.0
       '@langchain/langgraph': ^1.0.0
 
-  '@langchain/openai@0.5.18':
-    resolution: {integrity: sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q==}
-    engines: {node: '>=18'}
+  '@langchain/openai@1.4.4':
+    resolution: {integrity: sha512-mRr/X5rvlwPj6cSXPxbL+CtOqYANO1/+CQ3Z+5t48kWnrlgPYOazmA+UAWvqQOuwJ6LaYn3SFrt43rR4lte/Ow==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': '>=0.3.58 <0.4.0'
+      '@langchain/core': ^1.1.39
 
   '@microsoft/agents-activity@1.3.1':
     resolution: {integrity: sha512-4k44NrfEqXiSg49ofj8geV8ylPocqDLtZKKt0PFL9BvFV0n57X3y1s/fEbsf7Fkl3+P/R2XLyMB5atEGf/eRGg==}
@@ -3184,8 +3184,8 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+  openai@6.29.0:
+    resolution: {integrity: sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -3196,8 +3196,8 @@ packages:
       zod:
         optional: true
 
-  openai@6.29.0:
-    resolution: {integrity: sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==}
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -4498,7 +4498,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)':
+  '@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -4518,25 +4518,59 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
+  '@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)':
     dependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.10(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      uuid: 10.0.0
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
+    dependencies:
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.7.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
+    dependencies:
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@1.7.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 10.0.0
     optionalDependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
 
-  '@langchain/langgraph@1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)':
+  '@langchain/langgraph-sdk@1.7.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))':
     dependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
-      '@langchain/langgraph-sdk': 1.7.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.0
+      p-retry: 7.1.1
+      uuid: 10.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+
+  '@langchain/langgraph@1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)':
+    dependencies:
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
+      '@langchain/langgraph-sdk': 1.7.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.1.13
@@ -4549,10 +4583,27 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/mcp-adapters@1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@langchain/langgraph@1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))':
+  '@langchain/langgraph@1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)':
     dependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
-      '@langchain/langgraph': 1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
+      '@langchain/langgraph-sdk': 1.7.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.1.13
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@4.1.13)
+    transitivePeerDependencies:
+      - '@angular/core'
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/mcp-adapters@1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@langchain/langgraph@1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))':
+    dependencies:
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/langgraph': 1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       debug: 4.4.3
       zod: 4.1.13
@@ -4562,11 +4613,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@langchain/openai@0.5.18(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)':
+  '@langchain/openai@1.4.4(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)':
     dependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       js-tiktoken: 1.0.21
-      openai: 5.23.2(ws@8.18.3)(zod@4.1.13)
+      openai: 6.34.0(ws@8.18.3)(zod@4.1.13)
       zod: 4.1.13
     transitivePeerDependencies:
       - ws
@@ -6475,12 +6526,12 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langchain@1.2.32(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@4.1.13)):
+  langchain@1.2.32(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@4.1.13)):
     dependencies:
-      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
-      '@langchain/langgraph': 1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
-      langsmith: 0.5.10(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/core': 1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/langgraph': 1.2.2(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.40(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))
+      langsmith: 0.5.10(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
       uuid: 10.0.0
       zod: 4.1.13
     transitivePeerDependencies:
@@ -6509,6 +6560,21 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
       openai: 6.29.0(ws@8.18.3)(zod@4.1.13)
+      ws: 8.18.3
+
+  langsmith@0.5.10(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3):
+    dependencies:
+      '@types/uuid': 9.0.8
+      chalk: 5.6.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.3
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      openai: 6.34.0(ws@8.18.3)(zod@4.1.13)
       ws: 8.18.3
 
   leven@3.1.0: {}
@@ -6677,12 +6743,12 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@5.23.2(ws@8.18.3)(zod@4.1.13):
+  openai@6.29.0(ws@8.18.3)(zod@4.1.13):
     optionalDependencies:
       ws: 8.18.3
       zod: 4.1.13
 
-  openai@6.29.0(ws@8.18.3)(zod@4.1.13):
+  openai@6.34.0(ws@8.18.3)(zod@4.1.13):
     optionalDependencies:
       ws: 8.18.3
       zod: 4.1.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@langchain/mcp-adapters':
       specifier: ^1.1.3
       version: 1.1.3
+    '@langchain/openai':
+      specifier: ^0.5.0
+      version: 0.5.18
     '@microsoft/agents-activity':
       specifier: ^1.3.1
       version: 1.3.1
@@ -706,6 +709,15 @@ importers:
 
   tests:
     dependencies:
+      '@langchain/core':
+        specifier: 'catalog:'
+        version: 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      '@langchain/langgraph':
+        specifier: 'catalog:'
+        version: 1.2.2(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+      '@langchain/openai':
+        specifier: 'catalog:'
+        version: 0.5.18(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)
       '@microsoft/agents-a365-observability':
         specifier: workspace:*
         version: link:../packages/agents-a365-observability
@@ -763,6 +775,9 @@ importers:
       openai:
         specifier: 'catalog:'
         version: 6.29.0(ws@8.18.3)(zod@4.1.13)
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.13
     devDependencies:
       '@babel/preset-typescript':
         specifier: 'catalog:'
@@ -1404,6 +1419,12 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.0
       '@langchain/langgraph': ^1.0.0
+
+  '@langchain/openai@0.5.18':
+    resolution: {integrity: sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.58 <0.4.0'
 
   '@microsoft/agents-activity@1.3.1':
     resolution: {integrity: sha512-4k44NrfEqXiSg49ofj8geV8ylPocqDLtZKKt0PFL9BvFV0n57X3y1s/fEbsf7Fkl3+P/R2XLyMB5atEGf/eRGg==}
@@ -3163,6 +3184,18 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^4.1.12
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openai@6.29.0:
     resolution: {integrity: sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==}
     hasBin: true
@@ -4528,6 +4561,15 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+
+  '@langchain/openai@0.5.18(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3))(ws@8.18.3)':
+    dependencies:
+      '@langchain/core': 1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.18.3)(zod@4.1.13))(ws@8.18.3)
+      js-tiktoken: 1.0.21
+      openai: 5.23.2(ws@8.18.3)(zod@4.1.13)
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - ws
 
   '@microsoft/agents-activity@1.3.1':
     dependencies:
@@ -6634,6 +6676,11 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  openai@5.23.2(ws@8.18.3)(zod@4.1.13):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 4.1.13
 
   openai@6.29.0(ws@8.18.3)(zod@4.1.13):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ catalog:
   "@langchain/core": "^1.1.32"
   "@langchain/langgraph": "^1.2.2"
   "@langchain/mcp-adapters": "^1.1.3"
+  "@langchain/openai": "^0.5.0"
 
   # Microsoft 365 Agents SDK packages
   "@microsoft/agents-hosting": "^1.3.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,10 @@ catalog:
 
   # LangChain packages - use latest stable
   "langchain": "^1.2.31"
-  "@langchain/core": "^1.1.39"
+  "@langchain/core": "^1.1.32"
   "@langchain/langgraph": "^1.2.2"
   "@langchain/mcp-adapters": "^1.1.3"
-  "@langchain/openai": "^1.4.4"
+  "@langchain/openai": "^0.5.0"
 
   # Microsoft 365 Agents SDK packages
   "@microsoft/agents-hosting": "^1.3.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,10 @@ catalog:
 
   # LangChain packages - use latest stable
   "langchain": "^1.2.31"
-  "@langchain/core": "^1.1.32"
+  "@langchain/core": "^1.1.39"
   "@langchain/langgraph": "^1.2.2"
   "@langchain/mcp-adapters": "^1.1.3"
-  "@langchain/openai": "^0.5.0"
+  "@langchain/openai": "^1.4.4"
 
   # Microsoft 365 Agents SDK packages
   "@microsoft/agents-hosting": "^1.3.1"

--- a/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
+++ b/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
@@ -102,11 +102,12 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
       );
     });
 
-    it("should extract conversation/session ID from metadata", () => {
+    it("should map conversation_id to gen_ai.conversation.id and session_id to session.id", () => {
       const run: Partial<Run> = {
         extra: {
           metadata: {
             conversation_id: "conv-789",
+            session_id: "sess-123",
           },
         },
       };
@@ -114,10 +115,15 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
       Utils.setSessionIdAttribute(run as Run, mockSpan as Span);
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        OpenTelemetryConstants.SESSION_ID_KEY,
+        OpenTelemetryConstants.GEN_AI_CONVERSATION_ID_KEY,
         "conv-789"
       );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        OpenTelemetryConstants.SESSION_ID_KEY,
+        "sess-123"
+      );
     });
+
   });
 });
 

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { Tracer } from '@opentelemetry/api';
+import { SpanKind, Tracer } from '@opentelemetry/api';
 import { OpenTelemetryConstants } from '@microsoft/agents-a365-observability';
 import { OpenAIAgentsTraceProcessor } from '@microsoft/agents-a365-observability-extensions-openai';
 import { ObservabilityManager } from '@microsoft/agents-a365-observability';
@@ -117,32 +117,6 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
         processor.onSpanEnd(funcSpan);
         expect(otelSpans.has('func-1')).toBe(false);
-      });
-
-      it('should process handoff span', () => {
-        const traceData = { traceId: 'trace-3', name: 'Agent' } as any;
-        processor.onTraceStart(traceData);
-
-        const handoffSpan = {
-          spanId: 'handoff-1',
-          traceId: 'trace-3',
-          startedAt: new Date().toISOString(),
-          spanData: {
-            type: 'handoff' as const,
-            name: 'handoff_to_agent',
-            to_agent: 'specialist',
-            from_agent: 'main-agent',
-          },
-        } as any;
-
-        processor.onSpanStart(handoffSpan);
-
-        const otelSpans = (processor as any).otelSpans;
-        expect(otelSpans.has('handoff-1')).toBe(true);
-
-        processor.onSpanEnd(handoffSpan);
-        const reverseHandoffs = (processor as any).reverseHandoffsDict;
-        expect(reverseHandoffs.has('specialist:trace-3')).toBe(true);
       });
 
       it('should process agent span', () => {
@@ -272,45 +246,6 @@ describe('OpenAIAgentsTraceProcessor', () => {
     });
 
     describe('Complex Scenarios', () => {
-      it('should handle handoff with agent graph', () => {
-        const traceData = { traceId: 'trace-graph', name: 'Agent' } as any;
-        processor.onTraceStart(traceData);
-
-        // Create handoff
-        const handoff = {
-          spanId: 'handoff-graph',
-          traceId: 'trace-graph',
-          startedAt: new Date().toISOString(),
-          spanData: {
-            type: 'handoff' as const,
-            name: 'Handoff',
-            to_agent: 'child-agent',
-            from_agent: 'parent-agent',
-          },
-        } as any;
-
-        processor.onSpanStart(handoff);
-        processor.onSpanEnd(handoff);
-
-        // Create agent that receives handoff
-        const agent = {
-          spanId: 'agent-graph',
-          traceId: 'trace-graph',
-          startedAt: new Date().toISOString(),
-          spanData: {
-            type: 'agent' as const,
-            name: 'child-agent',
-          },
-        } as any;
-
-        processor.onSpanStart(agent);
-
-        const otelSpans = (processor as any).otelSpans;
-        expect(otelSpans.has('agent-graph')).toBe(true);
-
-        processor.onSpanEnd(agent);
-      });
-
       it('should handle multiple spans in same trace', () => {
         const traceData = { traceId: 'trace-multi', name: 'Agent' } as any;
         processor.onTraceStart(traceData);
@@ -810,5 +745,65 @@ describe('OpenAIAgentsTraceProcessor', () => {
       ]);
     });
 
+    it('maps Chat Completions usage (prompt_tokens/completion_tokens) from output[0].usage', async () => {
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
+      const traceData = { traceId: 'trace-usage-chat', name: 'Agent' } as any;
+      await processor.onTraceStart(traceData);
+
+      const genSpan = {
+        spanId: 'gen-usage-chat',
+        traceId: 'trace-usage-chat',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        spanData: {
+          type: 'generation' as const,
+          name: 'GenChat',
+          model: 'gpt-4',
+          output: [{
+            choices: [{ finish_reason: 'stop' }],
+            usage: { prompt_tokens: 20, completion_tokens: 11, total_tokens: 31 },
+          }],
+        },
+      } as any;
+
+      await processor.onSpanStart(genSpan);
+      await processor.onSpanEnd(genSpan);
+
+      const genMock = spansByName['GenChat'];
+      const attrs = genMock._attrs as Array<[string, unknown]>;
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY)?.[1]).toBe(20);
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY)?.[1]).toBe(11);
+    });
+
+    it('maps Responses API usage (input_tokens/output_tokens) from top-level usage', async () => {
+      const processor = new OpenAIAgentsTraceProcessor(tracer, {});
+      const traceData = { traceId: 'trace-usage-resp', name: 'Agent' } as any;
+      await processor.onTraceStart(traceData);
+
+      const genSpan = {
+        spanId: 'gen-usage-resp',
+        traceId: 'trace-usage-resp',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        spanData: {
+          type: 'generation' as const,
+          name: 'GenResp',
+          model: 'gpt-4',
+          usage: { input_tokens: 42, output_tokens: 7 },
+        },
+      } as any;
+
+      await processor.onSpanStart(genSpan);
+      await processor.onSpanEnd(genSpan);
+
+      const genMock = spansByName['GenResp'];
+      const attrs = genMock._attrs as Array<[string, unknown]>;
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY)?.[1]).toBe(42);
+      expect(attrs.find(([k]) => k === OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY)?.[1]).toBe(7);
+    });
+
   });
+
+  // SpanKind, caller.agent.name, handoff A→B, and error.type are validated by
+  // the integration test (openai-agent-instrument.test.ts).
 });

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { SpanKind, Tracer } from '@opentelemetry/api';
+import { Tracer } from '@opentelemetry/api';
 import { OpenTelemetryConstants } from '@microsoft/agents-a365-observability';
 import { OpenAIAgentsTraceProcessor } from '@microsoft/agents-a365-observability-extensions-openai';
 import { ObservabilityManager } from '@microsoft/agents-a365-observability';

--- a/tests/observability/integration/helpers/span-validators.ts
+++ b/tests/observability/integration/helpers/span-validators.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect } from "@jest/globals";
+import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
+import {
+  expectValidInputMessages,
+  expectValidOutputMessages,
+} from "../../extension/helpers/message-schema-validator";
+
+/**
+ * Validate instrumentation scope for a span
+ */
+export function validateInstrumentationScope(
+  span: ReadableSpan,
+  expectedName: string,
+  expectedVersion: string,
+): void {
+  expect(span.instrumentationScope).toBeDefined();
+  expect(span.instrumentationScope.name).toBe(expectedName);
+  expect(span.instrumentationScope.version).toBe(expectedVersion);
+}
+
+/**
+ * Validate basic span properties (traceId, id, timestamp)
+ */
+export function validateSpanProperties(span: ReadableSpan): void {
+  expect((span as any).traceId).toBeDefined();
+  expect((span as any).id).toBeDefined();
+  expect((span as any).timestamp).toBeDefined();
+}
+
+/**
+ * Validate parent-child span relationship via CUSTOM_PARENT_SPAN_ID_KEY
+ */
+export function validateParentChildRelationship(
+  childSpan: ReadableSpan,
+  parentSpan: ReadableSpan,
+): void {
+  expect(
+    childSpan.attributes[OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY],
+  ).toBe(`0x${(parentSpan as any).id}`);
+}
+
+/**
+ * Validate A365 message schema on a span's input/output messages.
+ * Calls expectValidInputMessages/expectValidOutputMessages from the shared
+ * message-schema-validator, which check version "0.1.0", roles, and parts.
+ */
+export function validateMessageSchema(span: ReadableSpan): void {
+  const inputMessages =
+    span.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY];
+  if (inputMessages !== undefined) {
+    expectValidInputMessages(inputMessages);
+  }
+
+  const outputMessages =
+    span.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY];
+  if (outputMessages !== undefined) {
+    expectValidOutputMessages(outputMessages);
+  }
+}
+
+/**
+ * Validate input message content structure
+ */
+export function validateInputMessageContent(
+  span: ReadableSpan,
+  expectations: {
+    hasRole?: string;
+    hasPartType?: string;
+    containsText?: string;
+  },
+): void {
+  const raw =
+    span.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string;
+  expect(raw).toBeDefined();
+  const parsed = JSON.parse(raw);
+  expect(parsed.version).toBe("0.1.0");
+  expect(parsed.messages.length).toBeGreaterThan(0);
+
+  if (expectations.hasRole) {
+    expect(
+      parsed.messages.some((m: any) => m.role === expectations.hasRole),
+    ).toBe(true);
+  }
+  if (expectations.hasPartType) {
+    expect(
+      parsed.messages.some((m: any) =>
+        m.parts?.some((p: any) => p.type === expectations.hasPartType),
+      ),
+    ).toBe(true);
+  }
+  if (expectations.containsText) {
+    const allText = JSON.stringify(parsed);
+    expect(allText).toContain(expectations.containsText);
+  }
+}
+
+/**
+ * Validate output message content structure
+ */
+export function validateOutputMessageContent(
+  span: ReadableSpan,
+  expectations: {
+    hasRole?: string;
+    hasPartType?: string;
+  },
+): void {
+  const raw =
+    span.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string;
+  expect(raw).toBeDefined();
+  const parsed = JSON.parse(raw);
+  expect(parsed.version).toBe("0.1.0");
+  expect(parsed.messages.length).toBeGreaterThan(0);
+
+  if (expectations.hasRole) {
+    expect(
+      parsed.messages.some((m: any) => m.role === expectations.hasRole),
+    ).toBe(true);
+  }
+  if (expectations.hasPartType) {
+    expect(
+      parsed.messages.some((m: any) =>
+        m.parts?.some((p: any) => p.type === expectations.hasPartType),
+      ),
+    ).toBe(true);
+  }
+}
+
+/**
+ * Wait for spans to accumulate with a polling timeout
+ */
+export async function waitForSpans(
+  spans: ReadableSpan[],
+  minCount: number,
+  timeoutMs: number = 5000,
+): Promise<void> {
+  const startTime = Date.now();
+  while (spans.length < minCount && Date.now() - startTime < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}

--- a/tests/observability/integration/langchain-agent-instrument.test.ts
+++ b/tests/observability/integration/langchain-agent-instrument.test.ts
@@ -1,0 +1,536 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "@jest/globals";
+import { getAzureOpenAIConfig, validateEnvironment } from "./conftest";
+import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { SpanKind } from "@opentelemetry/api";
+import { ObservabilityManager, Builder, OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
+import { LangChainTraceInstrumentor } from "@microsoft/agents-a365-observability-extensions-langchain";
+import * as LangChainCallbacks from "@langchain/core/callbacks/manager";
+import { AzureChatOpenAI } from "@langchain/openai";
+// moduleResolution: "node" in tests/tsconfig.json doesn't see package `exports` subpaths
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — runtime resolution works; TS resolution needs node16/bundler
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { ObservabilityBuilder } from "@microsoft/agents-a365-observability/dist/esm/ObservabilityBuilder";
+import { BaggageBuilder } from "@microsoft/agents-a365-observability";
+import {
+  validateInstrumentationScope,
+  validateSpanProperties,
+  validateMessageSchema,
+  validateInputMessageContent,
+  validateOutputMessageContent,
+  waitForSpans,
+} from "./helpers/span-validators";
+
+// The LangChain instrumentor uses hardcoded tracer name/version
+const TEST_INSTRUMENTATION_NAME = "agent365-langchain";
+const TEST_INSTRUMENTATION_VERSION = "1.0.0";
+
+describe("LangChain Trace Processor Integration Tests", () => {
+  let a365Observability: ObservabilityBuilder;
+  let consoleDirSpy: jest.SpyInstance;
+  let spans: ReadableSpan[] = [];
+
+  beforeAll(async () => {
+    validateEnvironment();
+    console.log("Setting up LangChain Trace Processor test suite...");
+
+    // Spy on console.dir which ConsoleSpanExporter uses
+    consoleDirSpy = jest
+      .spyOn(console, "dir")
+      .mockImplementation((obj: any) => {
+        spans.push(obj as ReadableSpan);
+      });
+
+    // Configure observability (must happen before instrumentor init)
+    a365Observability = ObservabilityManager.configure((builder: Builder) =>
+      builder.withService("LangChain Agent Instrumentation Test", "1.0.0"),
+    );
+
+    // Instrument LangChain callbacks and enable
+    LangChainTraceInstrumentor.instrument(LangChainCallbacks as any);
+    LangChainTraceInstrumentor.enable();
+
+    // Start observability
+    a365Observability.start();
+  });
+
+  afterAll(async () => {
+    console.log("Tearing down LangChain Trace Processor test suite...");
+
+    if (consoleDirSpy) {
+      consoleDirSpy.mockRestore();
+    }
+
+    LangChainTraceInstrumentor.disable();
+    LangChainTraceInstrumentor.resetInstance();
+
+    if (a365Observability) {
+      await a365Observability.shutdown();
+    }
+
+    console.log("LangChain Trace Processor test suite teardown complete");
+  });
+
+  beforeEach(() => {
+    spans = [];
+  });
+
+  it("validate chat span", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const model = new AzureChatOpenAI({
+        azureOpenAIApiKey: azureConfig.apiKey,
+        azureOpenAIEndpoint: azureConfig.endpoint,
+        azureOpenAIApiDeploymentName: azureConfig.deployment,
+        azureOpenAIApiVersion: azureConfig.apiVersion,
+      });
+
+      const agentName = "LangChain Test Agent";
+      const agent = createReactAgent({
+        llm: model,
+        tools: [],
+        name: agentName,
+      });
+
+      const prompt = "Say hello!";
+      const result = await agent.invoke({
+        messages: [{ role: "user", content: prompt }],
+      });
+
+      // Wait for spans
+      await waitForSpans(spans, 2);
+
+      // Verify we captured spans
+      expect(spans.length).toBeGreaterThanOrEqual(2);
+      console.log("Total spans captured:", spans.length);
+
+      // Output all the spans
+      spans.forEach((span, idx) => {
+        console.log(`\n--- Span ${idx + 1} of ${spans.length} ---`);
+        console.log(JSON.stringify(span, null, 2));
+      });
+
+      // Find the chat span (LLM inference)
+      const chatSpan = spans.find(
+        (span) =>
+          span.attributes[
+            OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY
+          ] === "chat",
+      );
+      expect(chatSpan).toBeDefined();
+      expect(chatSpan?.name?.toLowerCase()).toContain("chat");
+      console.log("Validate chat span");
+
+      if (chatSpan) {
+        validateInstrumentationScope(chatSpan, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
+        validateSpanProperties(chatSpan);
+        expect(chatSpan.kind).toBe(SpanKind.CLIENT);
+        expect(chatSpan.name.toLowerCase()).toContain("chat");
+
+        // Validate gen_ai attributes
+        expect(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
+        ).toBe("chat");
+        const provider = chatSpan.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY];
+        expect(typeof provider).toBe("string");
+        expect((provider as string).length).toBeGreaterThan(0);
+        expect(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY],
+        ).toBeDefined();
+        expect(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY],
+        ).toBeDefined();
+        expect(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY],
+        ).toBeDefined();
+
+        // Token usage from AzureChatOpenAI
+        const inputTokens = chatSpan.attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY];
+        const outputTokens = chatSpan.attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY];
+        expect(typeof inputTokens).toBe("number");
+        expect(typeof outputTokens).toBe("number");
+        expect(inputTokens as number).toBeGreaterThan(0);
+        expect(outputTokens as number).toBeGreaterThan(0);
+
+        // Validate A365 message schema
+        validateMessageSchema(chatSpan);
+        validateInputMessageContent(chatSpan, {
+          hasRole: "user",
+          hasPartType: "text",
+        });
+        validateOutputMessageContent(chatSpan, {
+          hasRole: "assistant",
+          hasPartType: "text",
+        });
+
+        // Detailed envelope + parts checks
+        const parsedInput = JSON.parse(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
+        );
+        expect(parsedInput.version).toBe("0.1.0");
+        expect(Array.isArray(parsedInput.messages)).toBe(true);
+        const userMsg = parsedInput.messages.find((m: any) => m.role === "user");
+        expect(userMsg).toBeDefined();
+        expect(Array.isArray(userMsg.parts)).toBe(true);
+        expect(userMsg.parts[0].type).toBe("text");
+        expect(typeof userMsg.parts[0].content).toBe("string");
+        expect(userMsg.parts[0].content).toContain(prompt);
+
+        const parsedOutput = JSON.parse(
+          chatSpan.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
+        );
+        expect(parsedOutput.version).toBe("0.1.0");
+        const assistantMsg = parsedOutput.messages.find((m: any) => m.role === "assistant");
+        expect(assistantMsg).toBeDefined();
+        expect(Array.isArray(assistantMsg.parts)).toBe(true);
+        expect(assistantMsg.parts[0].type).toBe("text");
+        expect(typeof assistantMsg.parts[0].content).toBe("string");
+        expect((assistantMsg.parts[0].content as string).length).toBeGreaterThan(0);
+
+        // Validate status
+        expect(chatSpan.status).toBeDefined();
+        expect(chatSpan.status.code).toBe(1);
+
+        console.log("Chat span validation passed");
+      }
+
+      // Verify the response
+      expect(result).toBeDefined();
+      console.log("Agent response received");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate agent span", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const model = new AzureChatOpenAI({
+        azureOpenAIApiKey: azureConfig.apiKey,
+        azureOpenAIEndpoint: azureConfig.endpoint,
+        azureOpenAIApiDeploymentName: azureConfig.deployment,
+        azureOpenAIApiVersion: azureConfig.apiVersion,
+      });
+
+      const agentName = "LangChain Agent Span Test";
+      const agent = createReactAgent({
+        llm: model,
+        tools: [],
+        name: agentName,
+      });
+
+      const result = await agent.invoke({
+        messages: [{ role: "user", content: "Say hello!" }],
+      });
+
+      await waitForSpans(spans, 2);
+
+      // Find and validate the agent span only
+      const agentSpan = spans.find(
+        (span) => span.name === `invoke_agent ${agentName}`,
+      );
+      expect(agentSpan).toBeDefined();
+      console.log("Validate agent span");
+
+      if (agentSpan) {
+        validateInstrumentationScope(agentSpan, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
+        validateSpanProperties(agentSpan);
+        expect(agentSpan.kind).toBe(SpanKind.SERVER);
+        expect(agentSpan.name).toBe(`invoke_agent ${agentName}`);
+        expect(
+          agentSpan.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
+        ).toBe("invoke_agent");
+        expect(
+          agentSpan.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY],
+        ).toBe(agentName);
+        // Top-level agent: no inbound caller
+        expect(
+          agentSpan.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY],
+        ).toBeUndefined();
+        expect(agentSpan.status).toBeDefined();
+        expect(agentSpan.status.code).toBe(1);
+        console.log("Agent span validation passed");
+      }
+
+      expect(result).toBeDefined();
+      console.log("Agent response received");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate execute_tool span", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const model = new AzureChatOpenAI({
+        azureOpenAIApiKey: azureConfig.apiKey,
+        azureOpenAIEndpoint: azureConfig.endpoint,
+        azureOpenAIApiDeploymentName: azureConfig.deployment,
+        azureOpenAIApiVersion: azureConfig.apiVersion,
+      });
+
+      const addTool = new DynamicStructuredTool({
+        name: "add_numbers",
+        description: "Add two numbers together",
+        schema: z.object({
+          a: z.number().describe("The first number"),
+          b: z.number().describe("The second number"),
+        }),
+        func: async ({ a, b }: { a: number; b: number }) => {
+          const result = a + b;
+          return `The sum of ${a} and ${b} is ${result}`;
+        },
+      });
+
+      const agentName = "MathAgent";
+      const agent = createReactAgent({
+        llm: model,
+        tools: [addTool],
+        name: agentName,
+      });
+
+      const prompt = "What is 15 plus 27?";
+      const result = await agent.invoke({
+        messages: [{ role: "user", content: prompt }],
+      });
+
+      // Wait for spans (agent + chat + tool, possibly more chat spans for multi-turn)
+      await waitForSpans(spans, 3);
+
+      // Verify we captured spans
+      expect(spans.length).toBeGreaterThanOrEqual(3);
+      console.log("Total spans captured:", spans.length);
+
+      // Output all the spans
+      spans.forEach((span, idx) => {
+        console.log(`\n--- Span ${idx + 1} of ${spans.length} ---`);
+        console.log(JSON.stringify(span, null, 2));
+      });
+
+      // Find and validate the tool execution span only
+      const toolSpan = spans.find(
+        (span) => span.name === "execute_tool add_numbers",
+      );
+      expect(toolSpan).toBeDefined();
+      console.log("Validate tool execution span");
+
+      if (toolSpan) {
+        validateInstrumentationScope(toolSpan, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
+        validateSpanProperties(toolSpan);
+        expect(toolSpan.kind).toBe(SpanKind.CLIENT);
+
+        // Validate tool-specific attributes
+        expect(
+          toolSpan.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
+        ).toBe("execute_tool");
+        expect(
+          toolSpan.attributes[OpenTelemetryConstants.GEN_AI_TOOL_NAME_KEY],
+        ).toBe("add_numbers");
+        expect(
+          toolSpan.attributes[OpenTelemetryConstants.GEN_AI_TOOL_TYPE_KEY],
+        ).toBe("extension");
+
+        // Validate tool args — serialized as JSON object
+        const toolArgs = toolSpan.attributes[
+          OpenTelemetryConstants.GEN_AI_TOOL_ARGS_KEY
+        ] as string;
+        expect(typeof toolArgs).toBe("string");
+        const parsedArgs = JSON.parse(toolArgs);
+        expect(parsedArgs.a).toBe(15);
+        expect(parsedArgs.b).toBe(27);
+
+        // Validate tool result — string results are wrapped as { result: "..." }
+        const toolResult = toolSpan.attributes[
+          OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY
+        ] as string;
+        expect(typeof toolResult).toBe("string");
+        const parsedResult = JSON.parse(toolResult);
+        expect(typeof parsedResult.result).toBe("string");
+        expect(parsedResult.result).toContain("42");
+        expect(parsedResult.result).toContain("The sum of 15 and 27");
+
+        // Validate status
+        expect(toolSpan.status).toBeDefined();
+        expect(toolSpan.status.code).toBe(1);
+
+        console.log("Tool execution span validated");
+      }
+
+      // Verify the response
+      expect(result).toBeDefined();
+      console.log("Agent response received");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate baggage propagation to spans", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const model = new AzureChatOpenAI({
+        azureOpenAIApiKey: azureConfig.apiKey,
+        azureOpenAIEndpoint: azureConfig.endpoint,
+        azureOpenAIApiDeploymentName: azureConfig.deployment,
+        azureOpenAIApiVersion: azureConfig.apiVersion,
+      });
+
+      const agentName = "BaggageTestAgent";
+      const agent = createReactAgent({
+        llm: model,
+        tools: [],
+        name: agentName,
+      });
+
+      // Set up baggage context with known values
+      const testTenantId = "test-tenant-123";
+      const testAgentId = "test-agent-456";
+      const testUserId = "test-user-789";
+      const testSessionId = "test-session-abc";
+      const testChannelName = "test-channel";
+      const testConversationId = "test-conversation-def";
+
+      const baggageScope = new BaggageBuilder()
+        .tenantId(testTenantId)
+        .agentId(testAgentId)
+        .userId(testUserId)
+        .sessionId(testSessionId)
+        .channelName(testChannelName)
+        .conversationId(testConversationId)
+        .build();
+
+      // Run agent within baggage scope
+      const result = await baggageScope.run(async () => {
+        return await agent.invoke({
+          messages: [{ role: "user", content: "Say hello!" }],
+        });
+      });
+
+      await waitForSpans(spans, 2);
+
+      expect(spans.length).toBeGreaterThanOrEqual(2);
+      console.log("Total spans captured:", spans.length);
+
+      // Validate baggage propagation on all spans
+      for (const span of spans) {
+        console.log(`Checking baggage on span: ${span.name}`);
+
+        expect(span.attributes[OpenTelemetryConstants.TENANT_ID_KEY]).toBe(testTenantId);
+        expect(span.attributes[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]).toBe(testAgentId);
+        expect(span.attributes[OpenTelemetryConstants.USER_ID_KEY]).toBe(testUserId);
+        expect(span.attributes[OpenTelemetryConstants.SESSION_ID_KEY]).toBe(testSessionId);
+        expect(span.attributes[OpenTelemetryConstants.CHANNEL_NAME_KEY]).toBe(testChannelName);
+        expect(span.attributes[OpenTelemetryConstants.GEN_AI_CONVERSATION_ID_KEY]).toBe(testConversationId);
+
+        console.log(`Baggage validated on span: ${span.name}`);
+      }
+
+      expect(result).toBeDefined();
+      console.log("Baggage propagation test passed");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate nested-agent caller.agent.name and error.type on tool failure", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+    if (!azureConfig) throw new Error("Azure OpenAI configuration is required");
+
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: azureConfig.apiKey,
+      azureOpenAIEndpoint: azureConfig.endpoint,
+      azureOpenAIApiDeploymentName: azureConfig.deployment,
+      azureOpenAIApiVersion: azureConfig.apiVersion,
+    });
+
+    // Nested agent: outer agent calls a tool that invokes an inner agent
+    const innerAgent = createReactAgent({ llm: model, tools: [], name: "InnerAgent" });
+    const delegateTool = new DynamicStructuredTool({
+      name: "delegate",
+      description: "Delegate the request to InnerAgent",
+      schema: z.object({ query: z.string() }),
+      // Pass the tool's RunnableConfig so the inner agent's run is linked as a child.
+      func: async ({ query }: { query: string }, _runManager, config) => {
+        const r = await innerAgent.invoke(
+          { messages: [{ role: "user", content: query }] },
+          config,
+        );
+        return JSON.stringify(r);
+      },
+    });
+    // Error-producing tool
+    const throwingTool = new DynamicStructuredTool({
+      name: "will_throw",
+      description: "Always fails with an error",
+      schema: z.object({}),
+      func: async () => { throw new Error("simulated failure"); },
+    });
+
+    const outerAgent = createReactAgent({
+      llm: model,
+      tools: [delegateTool, throwingTool],
+      name: "OuterAgent",
+    });
+
+    try {
+      await outerAgent.invoke({
+        messages: [{ role: "user", content: "Call the will_throw tool and also delegate 'ping' to InnerAgent." }],
+      });
+    } catch {
+      // Errors bubble up from the agent run; we still expect spans to be recorded.
+    }
+
+    await waitForSpans(spans, 3);
+
+    // LangGraph renames the nested agent run after the calling tool ("delegate"),
+    // so we look for any invoke_agent span that isn't the outer one and verify
+    // its caller.agent.name points back to OuterAgent via the parent-run walk.
+    const nestedAgentSpan = spans.find(
+      (s) =>
+        s.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY] === "invoke_agent" &&
+        s.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY] !== "OuterAgent" &&
+        s.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY] !== undefined,
+    );
+    expect(nestedAgentSpan).toBeDefined();
+    expect(nestedAgentSpan?.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY]).toBe("OuterAgent");
+    console.log(
+      `caller.agent.name via parent walk validated (nested agent name: ${nestedAgentSpan?.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY]})`,
+    );
+
+    const errorSpan = spans.find((s) => s.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY]);
+    expect(errorSpan).toBeDefined();
+    const errorType = errorSpan?.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY];
+    expect(typeof errorType).toBe("string");
+    expect((errorType as string).length).toBeGreaterThan(0);
+    expect(errorSpan?.attributes[OpenTelemetryConstants.ERROR_MESSAGE_KEY]).toContain("simulated failure");
+    console.log(`error.type="${errorType}", error.message validated`);
+  });
+});

--- a/tests/observability/integration/langchain-agent-instrument.test.ts
+++ b/tests/observability/integration/langchain-agent-instrument.test.ts
@@ -9,6 +9,8 @@ import { ObservabilityManager, Builder, OpenTelemetryConstants } from "@microsof
 import { LangChainTraceInstrumentor } from "@microsoft/agents-a365-observability-extensions-langchain";
 import * as LangChainCallbacks from "@langchain/core/callbacks/manager";
 import { AzureChatOpenAI } from "@langchain/openai";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — ts-jest module:commonjs cannot resolve package exports subpaths
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";

--- a/tests/observability/integration/langchain-agent-instrument.test.ts
+++ b/tests/observability/integration/langchain-agent-instrument.test.ts
@@ -9,9 +9,6 @@ import { ObservabilityManager, Builder, OpenTelemetryConstants } from "@microsof
 import { LangChainTraceInstrumentor } from "@microsoft/agents-a365-observability-extensions-langchain";
 import * as LangChainCallbacks from "@langchain/core/callbacks/manager";
 import { AzureChatOpenAI } from "@langchain/openai";
-// moduleResolution: "node" in tests/tsconfig.json doesn't see package `exports` subpaths
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — runtime resolution works; TS resolution needs node16/bundler
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";

--- a/tests/observability/integration/openai-agent-instrument.test.ts
+++ b/tests/observability/integration/openai-agent-instrument.test.ts
@@ -277,32 +277,32 @@ describe("OpenAI Trace Processor Integration Tests", () => {
       console.log("Validate agent span");
 
       validateInstrumentationScope(agentSpan!, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
-        validateSpanProperties(agentSpan!);
-        expect(agentSpan!.kind).toBe(SpanKind.SERVER);
-        expect(agentSpan!.name).toBe(`invoke_agent ${agentName}`);
-        expect(
-          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
-        ).toBe("invoke_agent");
-        expect(
-          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY],
-        ).toBe(agentName);
-        expect(
-          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
-        ).toBe("openai");
-        // Top-level agent: no inbound caller
-        expect(
-          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY],
-        ).toBeUndefined();
-        expect(
-          agentSpan!.attributes[OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY],
-        ).toBeUndefined();
-        expect(agentSpan!.status).toBeDefined();
-        expect(agentSpan!.status.code).toBe(1);
+      validateSpanProperties(agentSpan!);
+      expect(agentSpan!.kind).toBe(SpanKind.SERVER);
+      expect(agentSpan!.name).toBe(`invoke_agent ${agentName}`);
+      expect(
+        agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
+      ).toBe("invoke_agent");
+      expect(
+        agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY],
+      ).toBe(agentName);
+      expect(
+        agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
+      ).toBe("openai");
+      // Top-level agent: no inbound caller
+      expect(
+        agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY],
+      ).toBeUndefined();
+      expect(
+        agentSpan!.attributes[OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY],
+      ).toBeUndefined();
+      expect(agentSpan!.status).toBeDefined();
+      expect(agentSpan!.status.code).toBe(1);
 
-        // Validate parent-child relationship: generation span should reference agent span as custom parent
-        validateParentChildRelationship(generationSpan!, agentSpan!);
+      // Validate parent-child relationship: generation span should reference agent span as custom parent
+      validateParentChildRelationship(generationSpan!, agentSpan!);
 
-        console.log("✅ Agent span validation passed");
+      console.log("✅ Agent span validation passed");
 
       expect(result.finalOutput).toBeDefined();
       console.log("✅ Agent response received");

--- a/tests/observability/integration/openai-agent-instrument.test.ts
+++ b/tests/observability/integration/openai-agent-instrument.test.ts
@@ -5,12 +5,23 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "@jest/globals";
 import { getAzureOpenAIConfig, validateEnvironment } from "./conftest";
 import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { SpanKind } from "@opentelemetry/api";
 import { ObservabilityManager, Builder, OpenTelemetryConstants } from "@microsoft/agents-a365-observability";
 import { OpenAIAgentsTraceInstrumentor } from "@microsoft/agents-a365-observability-extensions-openai";
 import { Agent, run, tool } from "@openai/agents";
 import { OpenAIChatCompletionsModel } from "@openai/agents-openai";
 import { ObservabilityBuilder } from "@microsoft/agents-a365-observability/dist/esm/ObservabilityBuilder";
 import { AzureOpenAI } from "openai";
+import { BaggageBuilder } from "@microsoft/agents-a365-observability";
+import {
+  validateInstrumentationScope,
+  validateSpanProperties,
+  validateMessageSchema,
+  validateInputMessageContent,
+  validateOutputMessageContent,
+  validateParentChildRelationship,
+  waitForSpans,
+} from "./helpers/span-validators";
 
 // Test instrumentation constants
 const TEST_INSTRUMENTATION_NAME = "openai-agent-test-instrumentation";
@@ -23,7 +34,7 @@ describe("OpenAI Trace Processor Integration Tests", () => {
   let spans: ReadableSpan[] = [];
 
   beforeAll(async () => {
-   validateEnvironment();
+    validateEnvironment();
     console.log("Setting up OpenAI Trace Processor test suite...");
 
     // Also spy on console.dir which ConsoleSpanExporter uses
@@ -47,25 +58,19 @@ describe("OpenAI Trace Processor Integration Tests", () => {
 
     // Start observability
     a365Observability.start();
-
-    // Enable instrumentation
-    openAIAgentsTraceInstrumentor.enable();
   });
 
   afterAll(async () => {
     console.log("🧹 Tearing down OpenAI Trace Processor test suite...");
 
-    // Restore console.log
     if (consoleDirSpy) {
       consoleDirSpy.mockRestore();
     }
 
-    // Disable instrumentation
     if (openAIAgentsTraceInstrumentor) {
       openAIAgentsTraceInstrumentor.disable();
     }
 
-    // Shutdown observability
     if (a365Observability) {
       await a365Observability.shutdown();
     }
@@ -74,11 +79,10 @@ describe("OpenAI Trace Processor Integration Tests", () => {
   });
 
   beforeEach(() => {
-    // Clear spans for each test
     spans = [];
   });
 
-  it("validate agent span and generation span", async () => {
+  it("validate chat span", async () => {
     const azureConfig = getAzureOpenAIConfig();
 
     if (!azureConfig) {
@@ -95,9 +99,8 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         apiVersion: azureConfig.apiVersion,
       });
 
-      const agentName = "Test Agent";
       agent = new Agent({
-        name: agentName,
+        name: "Test Agent",
         model: new OpenAIChatCompletionsModel(
           azureClient as any,
           azureConfig.deployment,
@@ -109,12 +112,8 @@ describe("OpenAI Trace Processor Integration Tests", () => {
       const prompt = "Say hello!";
       const result = await run(agent, prompt);
 
-      // Wait for spans with timeout (poll until length >= 2 or timeout after 5s)
-      const startTime = Date.now();
-      const timeout = 5000;
-      while (spans.length < 2 && Date.now() - startTime < timeout) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+      // Wait for spans with timeout
+      await waitForSpans(spans, 2);
 
       // Verify we captured spans
       expect(spans.length).toBeGreaterThanOrEqual(2);
@@ -126,97 +125,108 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         console.log(JSON.stringify(span, null, 2));
       });
 
-      // Find the generation span
-      const generationSpan = spans.find((span) => span.name === "generation");
-      expect(generationSpan).toBeDefined();
-      console.log("Validate generation span");
-      if (generationSpan) {
-        validateInstrumentationScope(generationSpan);
-        validateSpanProperties(generationSpan);
+      // Find and validate the chat span
+      const inferenceSpan = spans.find(
+        (span) =>
+          span.attributes[
+            OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY
+          ] === "chat",
+      );
+      expect(inferenceSpan).toBeDefined();
+      expect(inferenceSpan?.name?.toLowerCase()).toContain("chat");
+      console.log("Validate inference span");
+      if (inferenceSpan) {
+        validateInstrumentationScope(inferenceSpan, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
+        validateSpanProperties(inferenceSpan);
+        expect(inferenceSpan.kind).toBe(SpanKind.CLIENT);
+        expect(inferenceSpan.name.toLowerCase()).toContain("chat");
 
         // Validate gen_ai attributes
         expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY
           ],
         ).toBe("chat");
         expect(
-          generationSpan.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
+          inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
         ).toBe("openai");
         expect(
-          generationSpan.attributes[
-            OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY
-          ],
-        ).toBe("openai");
-        expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_REQUEST_MODEL_KEY
           ],
         ).toBe(azureConfig.deployment);
         expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY
           ],
         ).toBeDefined();
         expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY
           ],
         ).toContain(prompt);
         expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY
           ],
         ).toBeDefined();
         expect(
-          generationSpan.attributes[
+          inferenceSpan.attributes[
             OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY
           ],
         ).toContain("chat.completion");
 
+        // Validate A365 message schema
+        validateMessageSchema(inferenceSpan);
+        validateInputMessageContent(inferenceSpan, {
+          hasRole: "user",
+          hasPartType: "text",
+          containsText: prompt,
+        });
+        validateOutputMessageContent(inferenceSpan, {
+          hasRole: "assistant",
+          hasPartType: "text",
+        });
+
+        // Detailed envelope + parts checks
+        const parsedInput = JSON.parse(
+          inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
+        );
+        expect(parsedInput.version).toBe("0.1.0");
+        expect(Array.isArray(parsedInput.messages)).toBe(true);
+        const userMsg = parsedInput.messages.find((m: any) => m.role === "user");
+        expect(userMsg).toBeDefined();
+        expect(Array.isArray(userMsg.parts)).toBe(true);
+        expect(userMsg.parts[0].type).toBe("text");
+        expect(typeof userMsg.parts[0].content).toBe("string");
+        expect(userMsg.parts[0].content).toContain(prompt);
+
+        const parsedOutput = JSON.parse(
+          inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
+        );
+        expect(parsedOutput.version).toBe("0.1.0");
+        const assistantMsg = parsedOutput.messages.find((m: any) => m.role === "assistant");
+        expect(assistantMsg).toBeDefined();
+        expect(Array.isArray(assistantMsg.parts)).toBe(true);
+        expect(assistantMsg.parts[0].type).toBe("text");
+        expect(typeof assistantMsg.parts[0].content).toBe("string");
+        expect((assistantMsg.parts[0].content as string).length).toBeGreaterThan(0);
+
+        // Token usage — our processor maps both Responses API (input_tokens/output_tokens)
+        // and Chat Completions (prompt_tokens/completion_tokens) into schema-defined attrs.
+        const inputTokens = inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_USAGE_INPUT_TOKENS_KEY];
+        const outputTokens = inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_USAGE_OUTPUT_TOKENS_KEY];
+        expect(typeof inputTokens).toBe("number");
+        expect(typeof outputTokens).toBe("number");
+        expect(inputTokens as number).toBeGreaterThan(0);
+        expect(outputTokens as number).toBeGreaterThan(0);
+
         // Validate status
-        expect(generationSpan.status).toBeDefined();
-        expect(generationSpan.status.code).toBe(1);
+        expect(inferenceSpan.status).toBeDefined();
+        expect(inferenceSpan.status.code).toBe(1);
 
-        console.log("✅ Generation span validation passed");
+        console.log("✅ Inference span validation passed");
       }
-
-      // Find and validate the agent span
-      const agentSpan = spans.find(
-        (span) => span.name === `invoke_agent ${agentName}`,
-      );
-      expect(agentSpan).toBeDefined();
-      console.log("Validate agent span");
-
-      if (agentSpan) {
-        validateInstrumentationScope(agentSpan);
-        validateSpanProperties(agentSpan);
-
-        // Validate agent-specific attributes
-        expect(
-          agentSpan.attributes[
-            OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY
-          ],
-        ).toBe("invoke_agent");
-        expect(
-          agentSpan.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
-        ).toBe("openai");
-        expect(
-          agentSpan?.attributes[
-            OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY
-          ],
-        ).toBeUndefined();
-
-        validateParentChildRelationship(generationSpan!, agentSpan);
-
-        // Validate status
-        expect(agentSpan.status).toBeDefined();
-        expect(agentSpan.status.code).toBe(1);
-
-        console.log("✅ Agent span validation passed");
-      }
-
-      console.log("✅ All span structure validation passed");
 
       // Verify the response
       expect(result.finalOutput).toBeDefined();
@@ -227,7 +237,82 @@ describe("OpenAI Trace Processor Integration Tests", () => {
     }
   });
 
-  it("Validate execution spans", async () => {
+  it("validate agent span", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const azureClient = new AzureOpenAI({
+        endpoint: azureConfig.endpoint,
+        deployment: azureConfig.deployment,
+        apiKey: azureConfig.apiKey,
+        apiVersion: azureConfig.apiVersion,
+      });
+
+      const agentName = "Agent Span Test Agent";
+      const agent = new Agent({
+        name: agentName,
+        model: new OpenAIChatCompletionsModel(
+          azureClient as any,
+          azureConfig.deployment,
+        ),
+        instructions: "You are a helpful assistant.",
+      });
+
+      const result = await run(agent, "Say hello!");
+      await waitForSpans(spans, 2);
+
+      // Find and validate the agent span only
+      const agentSpan = spans.find(
+        (span) => span.name === `invoke_agent ${agentName}`,
+      );
+      const generationSpan = spans.find(
+        (span) => span.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY] === "chat",
+      );
+      expect(agentSpan).toBeDefined();
+      expect(generationSpan).toBeDefined();
+      console.log("Validate agent span");
+
+      validateInstrumentationScope(agentSpan!, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
+        validateSpanProperties(agentSpan!);
+        expect(agentSpan!.kind).toBe(SpanKind.SERVER);
+        expect(agentSpan!.name).toBe(`invoke_agent ${agentName}`);
+        expect(
+          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY],
+        ).toBe("invoke_agent");
+        expect(
+          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY],
+        ).toBe(agentName);
+        expect(
+          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
+        ).toBe("openai");
+        // Top-level agent: no inbound caller
+        expect(
+          agentSpan!.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY],
+        ).toBeUndefined();
+        expect(
+          agentSpan!.attributes[OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY],
+        ).toBeUndefined();
+        expect(agentSpan!.status).toBeDefined();
+        expect(agentSpan!.status.code).toBe(1);
+
+        // Validate parent-child relationship: generation span should reference agent span as custom parent
+        validateParentChildRelationship(generationSpan!, agentSpan!);
+
+        console.log("✅ Agent span validation passed");
+
+      expect(result.finalOutput).toBeDefined();
+      console.log("✅ Agent response received");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate execute_tool span", async () => {
     const azureConfig = getAzureOpenAIConfig();
 
     if (!azureConfig) {
@@ -280,11 +365,7 @@ describe("OpenAI Trace Processor Integration Tests", () => {
       const prompt = "What is 15 plus 27?";
       const result = await run(agent, prompt);
 
-      const startTime = Date.now();
-      const timeout = 5000;
-      while (spans.length < 3 && Date.now() - startTime < timeout) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+      await waitForSpans(spans, 3);
 
       // Verify we captured spans
       expect(spans.length).toBeGreaterThanOrEqual(3);
@@ -296,39 +377,21 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         console.log(JSON.stringify(span, null, 2));
       });
 
-      // Find and validate the agent span
-      const agentSpan = spans.find(
-        (span) => span.name === `invoke_agent ${agentName}`,
-      );
-      expect(agentSpan).toBeDefined();
-
-      if (agentSpan) {
-        validateInstrumentationScope(agentSpan);
-        expect(
-          agentSpan.attributes[
-            OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY
-          ],
-        ).toBe("invoke_agent");
-        expect(
-          agentSpan.attributes[OpenTelemetryConstants.GEN_AI_PROVIDER_NAME_KEY],
-        ).toBe("openai");
-        console.log("✅ Agent span validated");
-      }
-
-      // Find and validate the generation span
-      const generationSpan = spans.find((span) => span.name === "generation");
-      expect(generationSpan).toBeDefined();
-
-      // Find and validate the tool execution span
+      // Find and validate the tool execution span only
       const toolSpan = spans.find(
         (span) => span.name === "execute_tool add_numbers",
       );
+      const agentSpanForTool = spans.find(
+        (span) => span.name === "invoke_agent Math Agent",
+      );
       expect(toolSpan).toBeDefined();
+      expect(agentSpanForTool).toBeDefined();
       console.log("Validate tool execution span");
 
       if (toolSpan) {
-        validateInstrumentationScope(toolSpan);
+        validateInstrumentationScope(toolSpan, TEST_INSTRUMENTATION_NAME, TEST_INSTRUMENTATION_VERSION);
         validateSpanProperties(toolSpan);
+        expect(toolSpan.kind).toBe(SpanKind.CLIENT);
 
         // Validate tool-specific attributes
         expect(
@@ -350,11 +413,12 @@ describe("OpenAI Trace Processor Integration Tests", () => {
           toolSpan.attributes[OpenTelemetryConstants.GEN_AI_TOOL_CALL_RESULT_KEY],
         ).toBe('{"result":"The sum of 15 and 27 is 42"}');
 
-        validateParentChildRelationship(toolSpan, agentSpan!);
-
         // Validate status
         expect(toolSpan.status).toBeDefined();
         expect(toolSpan.status.code).toBe(1);
+
+        // Validate parent-child relationship: tool span should reference agent span as custom parent
+        validateParentChildRelationship(toolSpan, agentSpanForTool!);
 
         console.log("✅ Tool execution span validated");
       }
@@ -368,35 +432,199 @@ describe("OpenAI Trace Processor Integration Tests", () => {
     }
   });
 
-  /**
-   * Validate instrumentation scope for a span
-   */
-  function validateInstrumentationScope(span: ReadableSpan): void {
-    expect(span.instrumentationScope).toBeDefined();
-    expect(span.instrumentationScope.name).toBe(TEST_INSTRUMENTATION_NAME);
-    expect(span.instrumentationScope.version).toBe(
-      TEST_INSTRUMENTATION_VERSION,
+  it("validate baggage propagation to spans", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const azureClient = new AzureOpenAI({
+        endpoint: azureConfig.endpoint,
+        deployment: azureConfig.deployment,
+        apiKey: azureConfig.apiKey,
+        apiVersion: azureConfig.apiVersion,
+      });
+
+      const agentName = "Baggage Test Agent";
+      const agent = new Agent({
+        name: agentName,
+        model: new OpenAIChatCompletionsModel(
+          azureClient as any,
+          azureConfig.deployment,
+        ),
+        instructions: "You are a helpful assistant.",
+      });
+
+      // Set up baggage context with known values
+      const testTenantId = "test-tenant-123";
+      const testAgentId = "test-agent-456";
+      const testUserId = "test-user-789";
+      const testSessionId = "test-session-abc";
+      const testChannelName = "test-channel";
+      const testConversationId = "test-conversation-def";
+
+      const baggageScope = new BaggageBuilder()
+        .tenantId(testTenantId)
+        .agentId(testAgentId)
+        .userId(testUserId)
+        .sessionId(testSessionId)
+        .channelName(testChannelName)
+        .conversationId(testConversationId)
+        .build();
+
+      // Run agent within baggage scope
+      const result = await baggageScope.run(async () => {
+        return await run(agent, "Say hello!");
+      });
+
+      await waitForSpans(spans, 2);
+
+      expect(spans.length).toBeGreaterThanOrEqual(2);
+      console.log("Total spans captured:", spans.length);
+
+      // Validate baggage propagation on all spans
+      for (const span of spans) {
+        console.log(`Checking baggage on span: ${span.name}`);
+
+        expect(span.attributes[OpenTelemetryConstants.TENANT_ID_KEY]).toBe(testTenantId);
+        expect(span.attributes[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]).toBe(testAgentId);
+        expect(span.attributes[OpenTelemetryConstants.USER_ID_KEY]).toBe(testUserId);
+        expect(span.attributes[OpenTelemetryConstants.SESSION_ID_KEY]).toBe(testSessionId);
+        expect(span.attributes[OpenTelemetryConstants.CHANNEL_NAME_KEY]).toBe(testChannelName);
+        expect(span.attributes[OpenTelemetryConstants.GEN_AI_CONVERSATION_ID_KEY]).toBe(testConversationId);
+
+        console.log(`✅ Baggage validated on span: ${span.name}`);
+      }
+
+      expect(result.finalOutput).toBeDefined();
+      console.log("✅ Baggage propagation test passed");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate handoff emits CLIENT InvokeAgent with caller + SERVER InvokeAgent for target", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+
+    if (!azureConfig) {
+      throw new Error("Azure OpenAI configuration is required");
+    }
+
+    try {
+      const azureClient = new AzureOpenAI({
+        endpoint: azureConfig.endpoint,
+        deployment: azureConfig.deployment,
+        apiKey: azureConfig.apiKey,
+        apiVersion: azureConfig.apiVersion,
+      });
+
+      const billingAgent = new Agent({
+        name: "BillingAgent",
+        model: new OpenAIChatCompletionsModel(azureClient as any, azureConfig.deployment),
+        instructions: "You handle billing-related questions. Respond briefly.",
+      });
+
+      const triageAgent = new Agent({
+        name: "TriageAgent",
+        model: new OpenAIChatCompletionsModel(azureClient as any, azureConfig.deployment),
+        instructions:
+          "For any question about billing, invoices, refunds, or payments, immediately hand off to BillingAgent. Do not answer directly.",
+        handoffs: [billingAgent],
+      });
+
+      const prompt = "I was double-charged on my invoice last month — can I get a refund?";
+      const result = await run(triageAgent, prompt);
+
+      await waitForSpans(spans, 3);
+      expect(spans.length).toBeGreaterThanOrEqual(3);
+
+      spans.forEach((span, idx) => {
+        console.log(`\n--- Span ${idx + 1} of ${spans.length} ---`);
+        console.log(JSON.stringify({ name: span.name, kind: span.kind, attributes: span.attributes }, null, 2));
+      });
+
+      // CLIENT-kind InvokeAgent span emitted for the handoff itself
+      const handoffSpan = spans.find(
+        (s) =>
+          s.kind === SpanKind.CLIENT &&
+          s.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY] === "invoke_agent" &&
+          s.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY] === "BillingAgent"
+      );
+      expect(handoffSpan).toBeDefined();
+      if (handoffSpan) {
+        expect(handoffSpan.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY]).toBe("TriageAgent");
+        expect(handoffSpan.name).toBe("invoke_agent BillingAgent");
+        console.log("✅ CLIENT-kind handoff InvokeAgent span validated");
+      }
+
+      // SERVER-kind InvokeAgent span emitted for BillingAgent's actual work
+      const billingAgentSpan = spans.find(
+        (s) =>
+          s.kind === SpanKind.SERVER &&
+          s.attributes[OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY] === "BillingAgent"
+      );
+      expect(billingAgentSpan).toBeDefined();
+      if (billingAgentSpan) {
+        expect(billingAgentSpan.attributes[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]).toBe("invoke_agent");
+        expect(billingAgentSpan.attributes[OpenTelemetryConstants.GEN_AI_CALLER_AGENT_NAME_KEY]).toBe("TriageAgent");
+        console.log("✅ SERVER-kind BillingAgent InvokeAgent span validated");
+      }
+
+      expect(result.finalOutput).toBeDefined();
+      console.log("✅ Handoff span validation passed");
+    } catch (error) {
+      console.error("Test error:", error);
+      throw error;
+    }
+  });
+
+  it("validate error.type on failing tool", async () => {
+    const azureConfig = getAzureOpenAIConfig();
+    if (!azureConfig) throw new Error("Azure OpenAI configuration is required");
+
+    const azureClient = new AzureOpenAI({
+      endpoint: azureConfig.endpoint,
+      deployment: azureConfig.deployment,
+      apiKey: azureConfig.apiKey,
+      apiVersion: azureConfig.apiVersion,
+    });
+
+    const throwingTool: any = tool({
+      name: "will_throw",
+      description: "Always fails",
+      parameters: { type: "object", properties: {}, additionalProperties: false } as any,
+      execute: async () => { throw new Error("simulated failure"); },
+    });
+
+    const agent = new Agent({
+      name: "ErrorAgent",
+      model: new OpenAIChatCompletionsModel(azureClient as any, azureConfig.deployment),
+      instructions: "Call the will_throw tool exactly once.",
+      tools: [throwingTool],
+    });
+
+    try {
+      await run(agent, "Please call the will_throw tool.");
+    } catch {
+      // run may surface the tool failure; spans should still be emitted
+    }
+
+    await waitForSpans(spans, 2);
+
+    // The failing tool should produce an execute_tool span with ERROR status + error.type attribute
+    const errorSpan = spans.find(
+      (s) => s.name === "execute_tool will_throw" && s.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY],
     );
-  }
-
-  /**
-   * Validate basic span properties (traceId, id, timestamp)
-   */
-  function validateSpanProperties(span: ReadableSpan): void {
-    expect((span as any).traceId).toBeDefined();
-    expect((span as any).id).toBeDefined();
-    expect((span as any).timestamp).toBeDefined();
-  }
-
-  /**
-   * Validate parent-child span relationship
-   */
-  function validateParentChildRelationship(
-    childSpan: ReadableSpan,
-    parentSpan: ReadableSpan,
-  ): void {
-    expect(
-      childSpan.attributes[OpenTelemetryConstants.CUSTOM_PARENT_SPAN_ID_KEY],
-    ).toBe(`0x${(parentSpan as any).id}`);
-  }
+    expect(errorSpan).toBeDefined();
+    const errorTypeValue = errorSpan?.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY];
+    expect(typeof errorTypeValue).toBe("string");
+    expect((errorTypeValue as string).length).toBeGreaterThan(0);
+    // The Agents SDK wraps tool failures — status code is ERROR, message describes tool failure
+    expect(errorSpan?.status.code).toBe(2); // SpanStatusCode.ERROR
+    expect(errorSpan?.status.message).toContain("tool");
+    console.log(`✅ error.type validated: type="${errorTypeValue}", message="${errorSpan?.status.message}"`);
+  });
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -41,9 +41,13 @@
     "@opentelemetry/sdk-node": "catalog:",
     "@opentelemetry/sdk-trace-base": "catalog:",
     "@opentelemetry/semantic-conventions": "catalog:",
+    "@langchain/core": "catalog:",
+    "@langchain/langgraph": "catalog:",
+    "@langchain/openai": "catalog:",
     "dotenv": "catalog:",
     "hono": "catalog:",
-    "openai": "catalog:"
+    "openai": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@babel/preset-typescript": "catalog:",

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "commonjs",
     "lib": ["ESNext"],
     "outDir": "./dist",
     "strict": true,
@@ -12,7 +12,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "types": ["jest", "node"]

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs", 
+    "module": "ESNext",
     "lib": ["ESNext"],
     "outDir": "./dist",
     "strict": true,
@@ -12,7 +12,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "types": ["jest", "node"]


### PR DESCRIPTION
## Summary

- **Schema alignment**: Normalize SpanKind, caller.agent.name, error.type, handoff lineage, and token usage across both chat-completions and Responses API shapes to match A365 observability schema definitions
- Add integration test for Lang chain. Refactor OpenAI integration test to add more coverage on attribute validation. 
## Test plan

- [ ] Unit tests pass for OpenAI and LangChain message contract validation
- [ ] Integration tests pass for both OpenAI and LangChain agent instrumentation
- [ ] `pnpm test` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)