### PR TITLE
Update prod scope

### DIFF
--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
@@ -5,7 +5,7 @@ import { RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
 import { ObservabilityConfigurationOptions } from './ObservabilityConfigurationOptions';
 
 // Default constants
-const PROD_OBSERVABILITY_SCOPE = 'https://api.powerplatform.com/.default';
+const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite';
 
 /**
  * Configuration for observability package.

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
@@ -5,7 +5,7 @@ import { RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
 import { ObservabilityConfigurationOptions } from './ObservabilityConfigurationOptions';
 
 // Default constants
-const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite';
+const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
 /**
  * Configuration for observability package.

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
@@ -21,7 +21,7 @@ export type ObservabilityConfigurationOptions = RuntimeConfigurationOptions & {
    *
    * @returns Array of OAuth scopes for observability service authentication.
    * @envvar A365_OBSERVABILITY_SCOPES_OVERRIDE - Space-separated list of scopes.
-   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']
+   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c/.default']
    */
   observabilityAuthenticationScopes?: () => string[];
 

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
@@ -21,7 +21,7 @@ export type ObservabilityConfigurationOptions = RuntimeConfigurationOptions & {
    *
    * @returns Array of OAuth scopes for observability service authentication.
    * @envvar A365_OBSERVABILITY_SCOPES_OVERRIDE - Space-separated list of scopes.
-   * @default ['https://api.powerplatform.com/.default']
+   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']
    */
   observabilityAuthenticationScopes?: () => string[];
 

--- a/packages/agents-a365-runtime/src/environment-utils.ts
+++ b/packages/agents-a365-runtime/src/environment-utils.ts
@@ -19,7 +19,7 @@ import { IConfigurationProvider } from './configuration/IConfigurationProvider';
  * @deprecated This constant is exported for backward compatibility only.
  * For new code, use `ObservabilityConfiguration.observabilityAuthenticationScopes` instead.
  */
-export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite';
+export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
 /**
  * Production MCP platform authentication scope.

--- a/packages/agents-a365-runtime/src/environment-utils.ts
+++ b/packages/agents-a365-runtime/src/environment-utils.ts
@@ -19,7 +19,7 @@ import { IConfigurationProvider } from './configuration/IConfigurationProvider';
  * @deprecated This constant is exported for backward compatibility only.
  * For new code, use `ObservabilityConfiguration.observabilityAuthenticationScopes` instead.
  */
-export const PROD_OBSERVABILITY_SCOPE = 'https://api.powerplatform.com/.default';
+export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite';
 
 /**
  * Production MCP platform authentication scope.

--- a/tests/observability/configuration/ObservabilityConfiguration.test.ts
+++ b/tests/observability/configuration/ObservabilityConfiguration.test.ts
@@ -53,7 +53,7 @@ describe('ObservabilityConfiguration', () => {
       const config = new ObservabilityConfiguration({
         observabilityAuthenticationScopes: () => undefined as unknown as string[]
       });
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
     });
 
     it('should fall back to env var when override not provided', () => {
@@ -65,19 +65,19 @@ describe('ObservabilityConfiguration', () => {
     it('should fall back to default when neither override nor env var', () => {
       delete process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE;
       const config = new ObservabilityConfiguration({});
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
     });
 
     it('should fall back to default when env var is empty string', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
     });
 
     it('should fall back to default when env var is whitespace only', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '   ';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
     });
 
     it('should return readonly array', () => {

--- a/tests/observability/configuration/ObservabilityConfiguration.test.ts
+++ b/tests/observability/configuration/ObservabilityConfiguration.test.ts
@@ -53,7 +53,7 @@ describe('ObservabilityConfiguration', () => {
       const config = new ObservabilityConfiguration({
         observabilityAuthenticationScopes: () => undefined as unknown as string[]
       });
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to env var when override not provided', () => {
@@ -65,19 +65,19 @@ describe('ObservabilityConfiguration', () => {
     it('should fall back to default when neither override nor env var', () => {
       delete process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE;
       const config = new ObservabilityConfiguration({});
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to default when env var is empty string', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to default when env var is whitespace only', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '   ';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should return readonly array', () => {

--- a/tests/runtime/environment-utils.test.ts
+++ b/tests/runtime/environment-utils.test.ts
@@ -29,7 +29,7 @@ describe('environment-utils', () => {
       const scopes = getObservabilityAuthenticationScope();
 
       expect(scopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
-      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite');
+      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c/.default');
     });
 
     it('should ignore A365_OBSERVABILITY_SCOPES_OVERRIDE env var (deprecated behavior)', () => {

--- a/tests/runtime/environment-utils.test.ts
+++ b/tests/runtime/environment-utils.test.ts
@@ -29,7 +29,7 @@ describe('environment-utils', () => {
       const scopes = getObservabilityAuthenticationScope();
 
       expect(scopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
-      expect(scopes[0]).toEqual('https://api.powerplatform.com/.default');
+      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite');
     });
 
     it('should ignore A365_OBSERVABILITY_SCOPES_OVERRIDE env var (deprecated behavior)', () => {


### PR DESCRIPTION
This pull request updates the default OAuth scope used for observability authentication across the codebase. The previous default scope (`https://api.powerplatform.com/.default`) has been replaced with a new, service-specific scope (`api://9b975845-388f-4429-889e-eab1ef63949c/Agent365.Observability.OtelWrite`). All relevant configuration files, constants, and tests have been updated to reflect this change.

**Configuration and Constant Updates:**

* Updated the `PROD_OBSERVABILITY_SCOPE` constant in both `ObservabilityConfiguration.ts` and `environment-utils.ts` to use the new observability scope value. [[1]](diffhunk://#diff-06b48e70d2530c3febc654540f58fa4155f32297916bd996da6ee415e81607cfL8-R8) [[2]](diffhunk://#diff-074f6ca0fb20d22c842f6c42a12178fa8b3dadd5e4026fe6dc29280d8ed71c91L22-R22)
* Changed the default value and documentation for the `observabilityAuthenticationScopes` option in `ObservabilityConfigurationOptions.ts` to reference the new scope.

**Test Updates:**

* Updated all relevant tests in `ObservabilityConfiguration.test.ts` to expect the new observability scope as the default. [[1]](diffhunk://#diff-a88411fbab0e39cb89d8c0bbf81bf35b602cabe133cb3c1f025ce741601eedcaL56-R56) [[2]](diffhunk://#diff-a88411fbab0e39cb89d8c0bbf81bf35b602cabe133cb3c1f025ce741601eedcaL68-R80)
* Modified the test in `environment-utils.test.ts` to check for the new scope in the returned values.