### PR TITLE
Update default observability authentication scope

### DIFF
--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
+import { PROD_OBSERVABILITY_SCOPE, RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
 import { ObservabilityConfigurationOptions } from './ObservabilityConfigurationOptions';
-
-// Default constants
-const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
 /**
  * Configuration for observability package.

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
@@ -5,7 +5,7 @@ import { RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
 import { ObservabilityConfigurationOptions } from './ObservabilityConfigurationOptions';
 
 // Default constants
-const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c';
+const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
 /**
  * Configuration for observability package.

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfiguration.ts
@@ -5,7 +5,7 @@ import { RuntimeConfiguration } from '@microsoft/agents-a365-runtime';
 import { ObservabilityConfigurationOptions } from './ObservabilityConfigurationOptions';
 
 // Default constants
-const PROD_OBSERVABILITY_SCOPE = 'https://api.powerplatform.com/.default';
+const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c';
 
 /**
  * Configuration for observability package.

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
@@ -21,7 +21,7 @@ export type ObservabilityConfigurationOptions = RuntimeConfigurationOptions & {
    *
    * @returns Array of OAuth scopes for observability service authentication.
    * @envvar A365_OBSERVABILITY_SCOPES_OVERRIDE - Space-separated list of scopes.
-   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c']
+   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c/.default']
    */
   observabilityAuthenticationScopes?: () => string[];
 

--- a/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
+++ b/packages/agents-a365-observability/src/configuration/ObservabilityConfigurationOptions.ts
@@ -21,7 +21,7 @@ export type ObservabilityConfigurationOptions = RuntimeConfigurationOptions & {
    *
    * @returns Array of OAuth scopes for observability service authentication.
    * @envvar A365_OBSERVABILITY_SCOPES_OVERRIDE - Space-separated list of scopes.
-   * @default ['https://api.powerplatform.com/.default']
+   * @default ['api://9b975845-388f-4429-889e-eab1ef63949c']
    */
   observabilityAuthenticationScopes?: () => string[];
 

--- a/packages/agents-a365-runtime/src/environment-utils.ts
+++ b/packages/agents-a365-runtime/src/environment-utils.ts
@@ -19,7 +19,7 @@ import { IConfigurationProvider } from './configuration/IConfigurationProvider';
  * @deprecated This constant is exported for backward compatibility only.
  * For new code, use `ObservabilityConfiguration.observabilityAuthenticationScopes` instead.
  */
-export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c';
+export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
 /**
  * Production MCP platform authentication scope.

--- a/packages/agents-a365-runtime/src/environment-utils.ts
+++ b/packages/agents-a365-runtime/src/environment-utils.ts
@@ -16,8 +16,8 @@ import { IConfigurationProvider } from './configuration/IConfigurationProvider';
 
 /**
  * Production observability authentication scope.
- * @deprecated This constant is exported for backward compatibility only.
- * For new code, use `ObservabilityConfiguration.observabilityAuthenticationScopes` instead.
+ * Single source of truth for the default observability scope value.
+ * For env-var-aware resolution, use `ObservabilityConfiguration.observabilityAuthenticationScopes`.
  */
 export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c/.default';
 
@@ -56,7 +56,6 @@ export const DEVELOPMENT_ENVIRONMENT_NAME = 'Development';
  */
 export function getObservabilityAuthenticationScope(): string[] {
   // Returns production default - use ObservabilityConfiguration for proper env var support
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: deprecated function using deprecated constant
   return [PROD_OBSERVABILITY_SCOPE];
 }
 

--- a/packages/agents-a365-runtime/src/environment-utils.ts
+++ b/packages/agents-a365-runtime/src/environment-utils.ts
@@ -19,7 +19,7 @@ import { IConfigurationProvider } from './configuration/IConfigurationProvider';
  * @deprecated This constant is exported for backward compatibility only.
  * For new code, use `ObservabilityConfiguration.observabilityAuthenticationScopes` instead.
  */
-export const PROD_OBSERVABILITY_SCOPE = 'https://api.powerplatform.com/.default';
+export const PROD_OBSERVABILITY_SCOPE = 'api://9b975845-388f-4429-889e-eab1ef63949c';
 
 /**
  * Production MCP platform authentication scope.

--- a/tests/observability/configuration/ObservabilityConfiguration.test.ts
+++ b/tests/observability/configuration/ObservabilityConfiguration.test.ts
@@ -53,7 +53,7 @@ describe('ObservabilityConfiguration', () => {
       const config = new ObservabilityConfiguration({
         observabilityAuthenticationScopes: () => undefined as unknown as string[]
       });
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
     });
 
     it('should fall back to env var when override not provided', () => {
@@ -65,19 +65,19 @@ describe('ObservabilityConfiguration', () => {
     it('should fall back to default when neither override nor env var', () => {
       delete process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE;
       const config = new ObservabilityConfiguration({});
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
     });
 
     it('should fall back to default when env var is empty string', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
     });
 
     it('should fall back to default when env var is whitespace only', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '   ';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['https://api.powerplatform.com/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
     });
 
     it('should return readonly array', () => {

--- a/tests/observability/configuration/ObservabilityConfiguration.test.ts
+++ b/tests/observability/configuration/ObservabilityConfiguration.test.ts
@@ -6,7 +6,7 @@ import {
   ObservabilityConfiguration,
   defaultObservabilityConfigurationProvider
 } from '../../../packages/agents-a365-observability/src';
-import { RuntimeConfiguration, DefaultConfigurationProvider, ClusterCategory } from '../../../packages/agents-a365-runtime/src';
+import { RuntimeConfiguration, DefaultConfigurationProvider, ClusterCategory, PROD_OBSERVABILITY_SCOPE } from '../../../packages/agents-a365-runtime/src';
 
 describe('ObservabilityConfiguration', () => {
   const originalEnv = process.env;
@@ -53,7 +53,7 @@ describe('ObservabilityConfiguration', () => {
       const config = new ObservabilityConfiguration({
         observabilityAuthenticationScopes: () => undefined as unknown as string[]
       });
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
     });
 
     it('should fall back to env var when override not provided', () => {
@@ -65,19 +65,19 @@ describe('ObservabilityConfiguration', () => {
     it('should fall back to default when neither override nor env var', () => {
       delete process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE;
       const config = new ObservabilityConfiguration({});
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
     });
 
     it('should fall back to default when env var is empty string', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
     });
 
     it('should fall back to default when env var is whitespace only', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '   ';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
+      expect(config.observabilityAuthenticationScopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
     });
 
     it('should return readonly array', () => {

--- a/tests/observability/configuration/ObservabilityConfiguration.test.ts
+++ b/tests/observability/configuration/ObservabilityConfiguration.test.ts
@@ -53,7 +53,7 @@ describe('ObservabilityConfiguration', () => {
       const config = new ObservabilityConfiguration({
         observabilityAuthenticationScopes: () => undefined as unknown as string[]
       });
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to env var when override not provided', () => {
@@ -65,19 +65,19 @@ describe('ObservabilityConfiguration', () => {
     it('should fall back to default when neither override nor env var', () => {
       delete process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE;
       const config = new ObservabilityConfiguration({});
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to default when env var is empty string', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should fall back to default when env var is whitespace only', () => {
       process.env.A365_OBSERVABILITY_SCOPES_OVERRIDE = '   ';
       const config = new ObservabilityConfiguration();
-      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c']);
+      expect(config.observabilityAuthenticationScopes).toEqual(['api://9b975845-388f-4429-889e-eab1ef63949c/.default']);
     });
 
     it('should return readonly array', () => {

--- a/tests/runtime/environment-utils.test.ts
+++ b/tests/runtime/environment-utils.test.ts
@@ -29,7 +29,7 @@ describe('environment-utils', () => {
       const scopes = getObservabilityAuthenticationScope();
 
       expect(scopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
-      expect(scopes[0]).toEqual('https://api.powerplatform.com/.default');
+      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c');
     });
 
     it('should ignore A365_OBSERVABILITY_SCOPES_OVERRIDE env var (deprecated behavior)', () => {

--- a/tests/runtime/environment-utils.test.ts
+++ b/tests/runtime/environment-utils.test.ts
@@ -29,7 +29,7 @@ describe('environment-utils', () => {
       const scopes = getObservabilityAuthenticationScope();
 
       expect(scopes).toEqual([PROD_OBSERVABILITY_SCOPE]);
-      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c');
+      expect(scopes[0]).toEqual('api://9b975845-388f-4429-889e-eab1ef63949c/.default');
     });
 
     it('should ignore A365_OBSERVABILITY_SCOPES_OVERRIDE env var (deprecated behavior)', () => {


### PR DESCRIPTION
## Summary
- Change the default observability authentication scope from `https://api.powerplatform.com/.default` to `api://9b975845-388f-4429-889e-eab1ef63949c` (Agent365 resource audience).
- Same value now works for both OBO (delegated) and S2S (client-credential) token acquisition.
- Updates `ObservabilityConfiguration`, the deprecated `PROD_OBSERVABILITY_SCOPE` constant in runtime, doc defaults, and test expectations.

## Test plan
- [x] `pnpm build` — all observability + runtime packages build clean
- [x] `pnpm test` — all 1233 tests across 61 suites pass
- [x] `pnpm --filter @microsoft/agents-a365-observability lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)