### PR TITLE
Make auth handler name configurable in AgenticTokenCache

### DIFF
--- a/packages/agents-a365-observability-hosting/src/caching/AgenticTokenCache.ts
+++ b/packages/agents-a365-observability-hosting/src/caching/AgenticTokenCache.ts
@@ -69,7 +69,8 @@ export class AgenticTokenCache {
         tenantId: string,
         turnContext: TurnContext,
         authorization: Authorization,
-        scopes: string[]
+        scopes: string[],
+        authHandlerName: string = 'agentic'
     ): Promise<void> {
         const key = AgenticTokenCache.makeKey(agentId, tenantId);
         if (!authorization) {
@@ -108,7 +109,7 @@ export class AgenticTokenCache {
             for (let attempt = 0; attempt <= maxRetries; attempt++) {
                 logger.info(`[AgenticTokenCache] Exchanging token attempt ${attempt + 1}/${maxRetries + 1}`);
                 try {
-                    const tokenResponse = await authorization.exchangeToken(turnContext, 'agentic', { scopes: entry.scopes });
+                    const tokenResponse = await authorization.exchangeToken(turnContext, authHandlerName, { scopes: entry.scopes });
                     if (!tokenResponse?.token) {
                         logger.error('[AgenticTokenCache] Undefined token returned');
                         entry.token = undefined;

--- a/tests/observability/extension/hosting/agentic-token-cache.test.ts
+++ b/tests/observability/extension/hosting/agentic-token-cache.test.ts
@@ -188,6 +188,49 @@ describe('AgenticTokenCacheInstance', () => {
     expect(map.has('agent-new:tenant-new')).toBe(true);
   });
 
+  it('passes authHandlerName to exchangeToken when provided', async () => {
+    const token = makeJwtWithExp(300);
+    const exchangeFn = jest.fn(async (..._args: any[]) => ({ token }));
+    const auth: AuthorizationStub = {
+      exchangeToken: exchangeFn,
+      getToken: async () => ({ token: 'unused' }),
+      signOut: async () => {},
+      onSignInSuccess: () => {},
+      onSignInFailure: () => {}
+    };
+    await AgenticTokenCacheInstance.RefreshObservabilityToken(
+      'agentHandler',
+      'tenantHandler',
+      asTurnContext(makeTurnContext()),
+      auth as any,
+      ['scope.read'],
+      'custom-handler'
+    );
+    expect(exchangeFn).toHaveBeenCalledTimes(1);
+    expect(exchangeFn.mock.calls[0][1]).toBe('custom-handler');
+  });
+
+  it('defaults authHandlerName to "agentic" when not provided', async () => {
+    const token = makeJwtWithExp(300);
+    const exchangeFn = jest.fn(async (..._args: any[]) => ({ token }));
+    const auth: AuthorizationStub = {
+      exchangeToken: exchangeFn,
+      getToken: async () => ({ token: 'unused' }),
+      signOut: async () => {},
+      onSignInSuccess: () => {},
+      onSignInFailure: () => {}
+    };
+    await AgenticTokenCacheInstance.RefreshObservabilityToken(
+      'agentDefault',
+      'tenantDefault',
+      asTurnContext(makeTurnContext()),
+      auth as any,
+      ['scope.read']
+    );
+    expect(exchangeFn).toHaveBeenCalledTimes(1);
+    expect(exchangeFn.mock.calls[0][1]).toBe('agentic');
+  });
+
   it('caps JWT exp claim to 24 hours', async () => {
     const { AgenticTokenCache } = require('@microsoft/agents-a365-observability-hosting');
     const cache = new AgenticTokenCache();


### PR DESCRIPTION
## Summary
- `RefreshObservabilityToken` hardcoded `'agentic'` as the OAuth connection / auth handler name passed to `authorization.exchangeToken`, forcing every consumer to register a handler with that exact name.
- Added an optional `authHandlerName` parameter that defaults to `'agentic'` so existing callers keep working, but hosts that register a differently-named connection can now thread their own name through.

## Test plan
- [x] `pnpm --filter @microsoft/agents-a365-observability-hosting build`
- [x] `pnpm --filter @microsoft/agents-a365-observability-hosting lint`
- [x] Full observability test suite (`tests/` jest, pattern `observability`): 648/648 passing
- [x] New tests cover both the default value and explicit override paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)