### PR TITLE
Add S2S path for MCP tools

### DIFF
--- a/packages/agents-a365-runtime/src/agentic-authorization-service.ts
+++ b/packages/agents-a365-runtime/src/agentic-authorization-service.ts
@@ -5,7 +5,20 @@ import { TurnContext, Authorization } from '@microsoft/agents-hosting';
 import { PROD_MCP_PLATFORM_AUTHENTICATION_SCOPE } from './environment-utils';
 
 /**
- * Service for handling agentic user authentication.
+ * A function that acquires an app-only access token for the given scopes using the
+ * OAuth 2.0 client credentials grant. No user context (TurnContext) is required.
+ *
+ * Callers provide an implementation typically backed by MSAL's
+ * `ConfidentialClientApplication.acquireTokenByClientCredential`.
+ *
+ * @param scopes The OAuth scopes to request (e.g., `['api://<audience>/.default']`).
+ * @returns A promise that resolves to the access token string.
+ */
+export type AppTokenProvider = (scopes: string[]) => Promise<string>;
+
+/**
+ * Service for handling agentic authentication — both user-delegated (OBO via TurnContext)
+ * and service-to-service (app-only via AppTokenProvider).
  */
 export class AgenticAuthenticationService {
   /**
@@ -49,5 +62,25 @@ export class AgenticAuthenticationService {
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional: maintaining backward compatibility for deprecated 3-param overload
     const effectiveScopes = scopes ?? [PROD_MCP_PLATFORM_AUTHENTICATION_SCOPE];
     return (await authorization.exchangeToken(turnContext, authHandlerName, { scopes: effectiveScopes })).token || '';
+  }
+
+  /**
+   * Gets an app-only token for service-to-service authentication using the client credentials grant.
+   * No user context (TurnContext) is required.
+   *
+   * @param tokenProvider A function that acquires tokens via `acquireTokenByClientCredential`.
+   * @param scopes The OAuth scopes to request.
+   * @returns The access token string.
+   * @throws Error if the token provider returns a falsy value.
+   */
+  public static async GetAgenticAppToken(
+    tokenProvider: AppTokenProvider,
+    scopes: string[]
+  ): Promise<string> {
+    const token = await tokenProvider(scopes);
+    if (!token) {
+      throw new Error('Client credentials token acquisition failed: token provider returned an empty or null token');
+    }
+    return token;
   }
 }

--- a/packages/agents-a365-tooling-extensions-claude/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-claude/src/McpToolRegistrationService.ts
@@ -106,7 +106,8 @@ export class McpToolRegistrationService {
     for (const server of servers) {
       // server.headers contains the per-audience Authorization token set by listToolServers.
       // Merge with non-auth headers (channelId, user-agent); server.headers auth takes precedence.
-      const baseHeaders = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
+      const effectiveAuthToken = gatewayAuthToken ?? server.headers?.Authorization ?? server.headers?.authorization;
+      const baseHeaders = Utility.GetToolRequestHeaders(effectiveAuthToken, turnContext, options);
       const headers = { ...baseHeaders, ...server.headers };
 
       // Add each server to the config object

--- a/packages/agents-a365-tooling-extensions-claude/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-claude/src/McpToolRegistrationService.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { McpToolServerConfigurationService, McpClientTool, Utility, MCPServerConfig, ToolOptions } from '@microsoft/agents-a365-tooling';
-import { AgenticAuthenticationService, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
+import { AgenticAuthenticationService, AppTokenProvider, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
 import { ClaudeToolingConfiguration, defaultClaudeToolingConfigurationProvider } from './configuration';
 
 // Agents SDK
@@ -44,29 +44,69 @@ export class McpToolRegistrationService {
     authHandlerName: string,
     turnContext: TurnContext,
     authToken: string
-  ): Promise<void> {
+  ): Promise<void>;
 
+  /**
+   * Registers MCP tool servers using S2S (client credentials) authentication.
+   * A TurnContext is not required for token acquisition but, when provided, enables
+   * request headers (x-ms-agentid, x-ms-channel-id) to be attached to MCP server calls.
+   * @param agentOptions The Claude Agent options to which MCP servers will be added.
+   * @param agenticAppId The agentic app id for which to discover servers.
+   * @param tokenProvider A function that acquires app-only tokens via client credentials.
+   * @param turnContext Optional TurnContext for request header composition.
+   */
+  async addToolServersToAgent(
+    agentOptions: Options,
+    agenticAppId: string,
+    tokenProvider: AppTokenProvider,
+    turnContext?: TurnContext
+  ): Promise<void>;
+
+  async addToolServersToAgent(
+    agentOptions: Options,
+    authorizationOrAgenticAppId: Authorization | string,
+    authHandlerNameOrTokenProvider: string | AppTokenProvider,
+    turnContext?: TurnContext,
+    authToken?: string
+  ): Promise<void> {
     if (!agentOptions) {
       throw new Error('Agent Options is Required');
     }
 
-    if (!authToken) {
-      const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
-      authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext, [scope]);
+    const options: ToolOptions = { orchestratorName: this.orchestratorName };
+    let servers: MCPServerConfig[];
+    let gatewayAuthToken: string | undefined;
+
+    if (typeof authorizationOrAgenticAppId === 'string') {
+      // S2S PATH: addToolServersToAgent(agentOptions, agenticAppId, tokenProvider, turnContext?)
+      const agenticAppId = authorizationOrAgenticAppId;
+      const tokenProvider = authHandlerNameOrTokenProvider as AppTokenProvider;
+
+      servers = await this.configService.listToolServers(agenticAppId, tokenProvider, turnContext, options);
+    } else {
+      // OBO PATH: addToolServersToAgent(agentOptions, authorization, authHandlerName, turnContext, authToken)
+      const authorization = authorizationOrAgenticAppId;
+      const authHandlerName = authHandlerNameOrTokenProvider as string;
+
+      if (!authToken) {
+        const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
+        authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext!, [scope]);
+      }
+
+      // Validate the authentication token
+      Utility.ValidateAuthToken(authToken);
+      gatewayAuthToken = authToken;
+
+      servers = await this.configService.listToolServers(turnContext!, authorization, authHandlerName, authToken, options);
     }
 
-    // Validate the authentication token
-    Utility.ValidateAuthToken(authToken);
-
-    const options: ToolOptions = { orchestratorName: this.orchestratorName };
-    const servers = await this.configService.listToolServers(turnContext, authorization, authHandlerName, authToken, options);
     const mcpServers: Record<string, McpServerConfig> = {};
     const tools: McpClientTool[] = [];
 
     for (const server of servers) {
       // server.headers contains the per-audience Authorization token set by listToolServers.
       // Merge with non-auth headers (channelId, user-agent); server.headers auth takes precedence.
-      const baseHeaders = Utility.GetToolRequestHeaders(authToken, turnContext, options);
+      const baseHeaders = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
       const headers = { ...baseHeaders, ...server.headers };
 
       // Add each server to the config object

--- a/packages/agents-a365-tooling-extensions-langchain/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-langchain/src/McpToolRegistrationService.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 // Microsoft Agent 365 SDK
-import { McpToolServerConfigurationService, Utility, ToolOptions, ChatHistoryMessage } from '@microsoft/agents-a365-tooling';
-import { AgenticAuthenticationService, OperationResult, OperationError, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
+import { McpToolServerConfigurationService, MCPServerConfig, Utility, ToolOptions, ChatHistoryMessage } from '@microsoft/agents-a365-tooling';
+import { AgenticAuthenticationService, AppTokenProvider, OperationResult, OperationError, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
 import { LangChainToolingConfiguration, defaultLangChainToolingConfigurationProvider } from './configuration';
 
 // Agents SDK
@@ -60,27 +60,67 @@ export class McpToolRegistrationService {
     authHandlerName: string,
     turnContext: TurnContext,
     authToken: string
-  ): Promise<ReactAgent> {
+  ): Promise<ReactAgent>;
 
+  /**
+   * Registers MCP tool servers using S2S (client credentials) authentication.
+   * A TurnContext is not required for token acquisition but, when provided, enables
+   * request headers (x-ms-agentid, x-ms-channel-id) to be attached to MCP server calls.
+   * @param agent The LangChain Agent instance to which MCP servers will be added.
+   * @param agenticAppId The agentic app id for which to discover servers.
+   * @param tokenProvider A function that acquires app-only tokens via client credentials.
+   * @param turnContext Optional TurnContext for request header composition.
+   * @returns The updated Agent instance with registered MCP servers.
+   */
+  async addToolServersToAgent(
+    agent: ReactAgent,
+    agenticAppId: string,
+    tokenProvider: AppTokenProvider,
+    turnContext?: TurnContext
+  ): Promise<ReactAgent>;
+
+  async addToolServersToAgent(
+    agent: ReactAgent,
+    authorizationOrAgenticAppId: Authorization | string,
+    authHandlerNameOrTokenProvider: string | AppTokenProvider,
+    turnContext?: TurnContext,
+    authToken?: string
+  ): Promise<ReactAgent> {
     if (!agent) {
       throw new Error('Langchain Agent is Required');
     }
 
-    if (!authToken) {
-      const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
-      authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext, [scope]);
+    const options: ToolOptions = { orchestratorName: this.orchestratorName };
+    let servers: MCPServerConfig[];
+    let gatewayAuthToken: string | undefined;
+
+    if (typeof authorizationOrAgenticAppId === 'string') {
+      // S2S PATH
+      const agenticAppId = authorizationOrAgenticAppId;
+      const tokenProvider = authHandlerNameOrTokenProvider as AppTokenProvider;
+
+      servers = await this.configService.listToolServers(agenticAppId, tokenProvider, turnContext, options);
+    } else {
+      // OBO PATH
+      const authorization = authorizationOrAgenticAppId;
+      const authHandlerName = authHandlerNameOrTokenProvider as string;
+
+      if (!authToken) {
+        const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
+        authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext!, [scope]);
+      }
+
+      Utility.ValidateAuthToken(authToken);
+      gatewayAuthToken = authToken;
+
+      servers = await this.configService.listToolServers(turnContext!, authorization, authHandlerName, authToken, options);
     }
 
-    // Validate the authentication token
-    Utility.ValidateAuthToken(authToken);
-
-    const options: ToolOptions = { orchestratorName: this.orchestratorName };
-    const servers = await this.configService.listToolServers(turnContext, authorization, authHandlerName, authToken, options);
     const mcpServers: Record<string, Connection> = {};
 
     for (const server of servers) {
       // Merge base headers (channel, user-agent) with per-audience Authorization from server.headers
-      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(authToken, turnContext, options);
+      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
       const headers: Record<string, string> = { ...baseHeaders, ...server.headers };
 
       // Create Connection instance for LangChain agents

--- a/packages/agents-a365-tooling-extensions-langchain/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-langchain/src/McpToolRegistrationService.ts
@@ -120,7 +120,8 @@ export class McpToolRegistrationService {
 
     for (const server of servers) {
       // Merge base headers (channel, user-agent) with per-audience Authorization from server.headers
-      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
+      const toolRequestAuthToken = gatewayAuthToken ?? server.headers?.Authorization ?? server.headers?.authorization;
+      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(toolRequestAuthToken, turnContext, options);
       const headers: Record<string, string> = { ...baseHeaders, ...server.headers };
 
       // Create Connection instance for LangChain agents

--- a/packages/agents-a365-tooling-extensions-openai/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-openai/src/McpToolRegistrationService.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { v4 as uuidv4 } from 'uuid';
-import { McpToolServerConfigurationService, Utility, ToolOptions, ChatHistoryMessage } from '@microsoft/agents-a365-tooling';
-import { AgenticAuthenticationService, OperationResult, OperationError, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
+import { McpToolServerConfigurationService, MCPServerConfig, Utility, ToolOptions, ChatHistoryMessage } from '@microsoft/agents-a365-tooling';
+import { AgenticAuthenticationService, AppTokenProvider, OperationResult, OperationError, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
 import { OpenAIToolingConfiguration, defaultOpenAIToolingConfigurationProvider } from './configuration';
 
 // Agents SDK
@@ -48,27 +48,67 @@ export class McpToolRegistrationService {
     authHandlerName: string,
     turnContext: TurnContext,
     authToken: string
-  ): Promise<Agent> {
+  ): Promise<Agent>;
 
+  /**
+   * Registers MCP tool servers using S2S (client credentials) authentication.
+   * A TurnContext is not required for token acquisition but, when provided, enables
+   * request headers (x-ms-agentid, x-ms-channel-id) to be attached to MCP server calls.
+   * @param agent The OpenAI Agent instance to which MCP servers will be added.
+   * @param agenticAppId The agentic app id for which to discover servers.
+   * @param tokenProvider A function that acquires app-only tokens via client credentials.
+   * @param turnContext Optional TurnContext for request header composition.
+   * @returns The updated Agent instance with registered MCP servers.
+   */
+  async addToolServersToAgent(
+    agent: Agent,
+    agenticAppId: string,
+    tokenProvider: AppTokenProvider,
+    turnContext?: TurnContext
+  ): Promise<Agent>;
+
+  async addToolServersToAgent(
+    agent: Agent,
+    authorizationOrAgenticAppId: Authorization | string,
+    authHandlerNameOrTokenProvider: string | AppTokenProvider,
+    turnContext?: TurnContext,
+    authToken?: string
+  ): Promise<Agent> {
     if (!agent) {
       throw new Error('Agent is Required');
     }
 
-    if (!authToken) {
-      const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
-      authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext, [scope]);
+    const options: ToolOptions = { orchestratorName: this.orchestratorName };
+    let servers: MCPServerConfig[];
+    let gatewayAuthToken: string | undefined;
+
+    if (typeof authorizationOrAgenticAppId === 'string') {
+      // S2S PATH
+      const agenticAppId = authorizationOrAgenticAppId;
+      const tokenProvider = authHandlerNameOrTokenProvider as AppTokenProvider;
+
+      servers = await this.configService.listToolServers(agenticAppId, tokenProvider, turnContext, options);
+    } else {
+      // OBO PATH
+      const authorization = authorizationOrAgenticAppId;
+      const authHandlerName = authHandlerNameOrTokenProvider as string;
+
+      if (!authToken) {
+        const scope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
+        authToken = await AgenticAuthenticationService.GetAgenticUserToken(authorization, authHandlerName, turnContext!, [scope]);
+      }
+
+      Utility.ValidateAuthToken(authToken);
+      gatewayAuthToken = authToken;
+
+      servers = await this.configService.listToolServers(turnContext!, authorization, authHandlerName, authToken, options);
     }
 
-    // Validate the authentication token
-    Utility.ValidateAuthToken(authToken);
-
-    const options: ToolOptions = { orchestratorName: this.orchestratorName };
-    const servers = await this.configService.listToolServers(turnContext, authorization, authHandlerName, authToken, options);
     const mcpServers: MCPServerStreamableHttp[] = [];
 
     for (const server of servers) {
       // Merge base headers (channel, user-agent) with per-audience Authorization from server.headers
-      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(authToken, turnContext, options);
+      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
       const headers: Record<string, string> = { ...baseHeaders, ...server.headers };
 
       // Create MCPServerStreamableHttp instance for OpenAI agents

--- a/packages/agents-a365-tooling-extensions-openai/src/McpToolRegistrationService.ts
+++ b/packages/agents-a365-tooling-extensions-openai/src/McpToolRegistrationService.ts
@@ -108,7 +108,8 @@ export class McpToolRegistrationService {
 
     for (const server of servers) {
       // Merge base headers (channel, user-agent) with per-audience Authorization from server.headers
-      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(gatewayAuthToken, turnContext, options);
+      const toolRequestAuthToken = gatewayAuthToken ?? server.headers?.Authorization ?? server.headers?.authorization;
+      const baseHeaders: Record<string, string> = Utility.GetToolRequestHeaders(toolRequestAuthToken, turnContext, options);
       const headers: Record<string, string> = { ...baseHeaders, ...server.headers };
 
       // Create MCPServerStreamableHttp instance for OpenAI agents

--- a/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
+++ b/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
 import { TurnContext, Authorization } from '@microsoft/agents-hosting';
-import { OperationResult, OperationError, IConfigurationProvider, AgenticAuthenticationService, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
+import { OperationResult, OperationError, IConfigurationProvider, AgenticAuthenticationService, AppTokenProvider, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
 import { MCPServerConfig, MCPServerManifestEntry, McpClientTool, ToolOptions } from './contracts';
 import { ChatHistoryMessage, ChatMessageRequest } from './models/index';
 import { Utility } from './Utility';
@@ -70,24 +70,64 @@ export class McpToolServerConfigurationService {
    */
   async listToolServers(turnContext: TurnContext, authorization: Authorization, authHandlerName: string, authToken?: string, options?: ToolOptions): Promise<MCPServerConfig[]>;
 
+  /**
+   * Return MCP server definitions for the given agent using service-to-service (S2S) authentication.
+   * Uses an AppTokenProvider to acquire tokens via the OAuth 2.0 client credentials grant.
+   * A TurnContext is not required for token acquisition but, when provided, enables
+   * request headers (x-ms-agentid, x-ms-channel-id) to be attached to gateway and server calls.
+   *
+   * @param agenticAppId The agentic app id for which to discover servers.
+   * @param tokenProvider A function that acquires app-only tokens via client credentials.
+   * @param turnContext Optional TurnContext for request header composition. Does not affect token acquisition.
+   * @param options Optional tool options when calling the gateway.
+   * @returns A promise resolving to an array of normalized MCP server configuration objects.
+   */
+  async listToolServers(agenticAppId: string, tokenProvider: AppTokenProvider, turnContext?: TurnContext, options?: ToolOptions): Promise<MCPServerConfig[]>;
+
   async listToolServers(
     agenticAppIdOrTurnContext: string | TurnContext,
-    authTokenOrAuthorization: string | Authorization,
-    optionsOrAuthHandlerName?: ToolOptions | string,
-    authTokenOrOptions?: string | ToolOptions,
+    authTokenOrAuthorizationOrTokenProvider: string | Authorization | AppTokenProvider,
+    optionsOrAuthHandlerNameOrTurnContext?: ToolOptions | string | TurnContext,
+    authTokenOrOptionsOrToolOptions?: string | ToolOptions,
     options?: ToolOptions
   ): Promise<MCPServerConfig[]> {
     // Detect which signature is being used based on the type of the first parameter
     if (typeof agenticAppIdOrTurnContext === 'string') {
-      // LEGACY PATH: listToolServers(agenticAppId, authToken, options?)
       const agenticAppId = agenticAppIdOrTurnContext;
 
+      if (typeof authTokenOrAuthorizationOrTokenProvider === 'function') {
+        // S2S PATH: listToolServers(agenticAppId, tokenProvider, turnContext?, options?)
+        const tokenProvider = authTokenOrAuthorizationOrTokenProvider;
+        // Third param is either a TurnContext object, a ToolOptions object, or undefined
+        const thirdParam = optionsOrAuthHandlerNameOrTurnContext;
+        const isTurnContext = thirdParam != null && typeof thirdParam === 'object' && 'activity' in thirdParam;
+        const turnContext = isTurnContext ? thirdParam as TurnContext : undefined;
+        const toolOptions = isTurnContext
+          ? authTokenOrOptionsOrToolOptions as ToolOptions | undefined
+          : thirdParam as ToolOptions | undefined;
+
+        // Acquire a gateway token via client credentials
+        const gatewayScope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
+        const authToken = await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [gatewayScope]);
+
+        const servers = await (this.isDevScenario()
+          ? this.getMCPServerConfigsFromManifest()
+          : this.getMCPServerConfigsFromToolingGateway(agenticAppId, authToken, turnContext, toolOptions));
+
+        const acquire = this.isDevScenario()
+          ? this.createDevTokenAcquirer()
+          : this.createS2sTokenAcquirer(tokenProvider);
+
+        return await this.attachPerAudienceTokens(servers, acquire);
+      }
+
+      // LEGACY PATH: listToolServers(agenticAppId, authToken, options?)
       // Runtime validation for legacy signature parameters
-      if (typeof authTokenOrAuthorization !== 'string') {
+      if (typeof authTokenOrAuthorizationOrTokenProvider !== 'string') {
         throw new Error('authToken must be a string when using the legacy listToolServers(agenticAppId, authToken) signature');
       }
-      const authToken = authTokenOrAuthorization;
-      const toolOptions = optionsOrAuthHandlerName as ToolOptions | undefined;
+      const authToken = authTokenOrAuthorizationOrTokenProvider;
+      const toolOptions = optionsOrAuthHandlerNameOrTurnContext as ToolOptions | undefined;
 
       const servers = await (this.isDevScenario()
         ? this.getMCPServerConfigsFromManifest()
@@ -104,20 +144,23 @@ export class McpToolServerConfigurationService {
 
       return await this.attachPerAudienceTokens(servers, acquire);
     } else {
-      // NEW PATH: listToolServers(turnContext, authorization, authHandlerName, authToken?, options?)
+      // OBO PATH: listToolServers(turnContext, authorization, authHandlerName, authToken?, options?)
       const turnContext = agenticAppIdOrTurnContext;
 
       // Runtime validation for new signature parameters
-      if (typeof authTokenOrAuthorization === 'string') {
+      if (typeof authTokenOrAuthorizationOrTokenProvider === 'string') {
         throw new Error('authorization must be an Authorization object when using the new listToolServers(turnContext, authorization, authHandlerName) signature');
       }
-      if (typeof optionsOrAuthHandlerName !== 'string') {
+      if (typeof authTokenOrAuthorizationOrTokenProvider === 'function') {
+        throw new Error('tokenProvider is not supported with TurnContext — use the listToolServers(agenticAppId, tokenProvider) overload instead');
+      }
+      if (typeof optionsOrAuthHandlerNameOrTurnContext !== 'string') {
         throw new Error('authHandlerName must be a string when using the new listToolServers(turnContext, authorization, authHandlerName) signature');
       }
 
-      const authorization = authTokenOrAuthorization;
-      const authHandlerName = optionsOrAuthHandlerName;
-      let authToken = authTokenOrOptions as string | undefined;
+      const authorization = authTokenOrAuthorizationOrTokenProvider;
+      const authHandlerName = optionsOrAuthHandlerNameOrTurnContext;
+      let authToken = authTokenOrOptionsOrToolOptions as string | undefined;
       const toolOptions = options;
 
       // Auto-generate token if not provided
@@ -245,6 +288,21 @@ export class McpToolServerConfigurationService {
       );
       if (!token) {
         throw new Error(`Failed to obtain token for MCP server '${server.mcpServerName}' (scope: ${scope})`);
+      }
+      return token;
+    };
+  }
+
+  /**
+   * Returns a TokenAcquirer that acquires app-only tokens via client credentials (S2S).
+   * Uses AgenticAuthenticationService.GetAgenticAppToken which delegates to the caller-provided
+   * AppTokenProvider. Throws if the provider returns a falsy token.
+   */
+  private createS2sTokenAcquirer(tokenProvider: AppTokenProvider): TokenAcquirer {
+    return async (server, scope) => {
+      const token = await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [scope]);
+      if (!token) {
+        throw new Error(`Failed to obtain S2S token for MCP server '${server.mcpServerName}' (scope: ${scope})`);
       }
       return token;
     };

--- a/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
+++ b/packages/agents-a365-tooling/src/McpToolServerConfigurationService.ts
@@ -104,15 +104,17 @@ export class McpToolServerConfigurationService {
         const turnContext = isTurnContext ? thirdParam as TurnContext : undefined;
         const toolOptions = isTurnContext
           ? authTokenOrOptionsOrToolOptions as ToolOptions | undefined
-          : thirdParam as ToolOptions | undefined;
-
-        // Acquire a gateway token via client credentials
-        const gatewayScope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
-        const authToken = await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [gatewayScope]);
+          // When thirdParam is not a TurnContext (undefined or ToolOptions), check both the 3rd and 4th args
+          : (thirdParam as ToolOptions | undefined) ?? (authTokenOrOptionsOrToolOptions as ToolOptions | undefined);
 
         const servers = await (this.isDevScenario()
           ? this.getMCPServerConfigsFromManifest()
-          : this.getMCPServerConfigsFromToolingGateway(agenticAppId, authToken, turnContext, toolOptions));
+          : (async () => {
+              // Acquire a gateway token via client credentials only when calling the gateway
+              const gatewayScope = this.configProvider.getConfiguration().mcpPlatformAuthenticationScope;
+              const authToken = await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [gatewayScope]);
+              return this.getMCPServerConfigsFromToolingGateway(agenticAppId, authToken, turnContext, toolOptions);
+            })());
 
         const acquire = this.isDevScenario()
           ? this.createDevTokenAcquirer()
@@ -299,12 +301,8 @@ export class McpToolServerConfigurationService {
    * AppTokenProvider. Throws if the provider returns a falsy token.
    */
   private createS2sTokenAcquirer(tokenProvider: AppTokenProvider): TokenAcquirer {
-    return async (server, scope) => {
-      const token = await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [scope]);
-      if (!token) {
-        throw new Error(`Failed to obtain S2S token for MCP server '${server.mcpServerName}' (scope: ${scope})`);
-      }
-      return token;
+    return async (_server, scope) => {
+      return await AgenticAuthenticationService.GetAgenticAppToken(tokenProvider, [scope]);
     };
   }
 

--- a/tests/runtime/agentic-authorization-service.test.ts
+++ b/tests/runtime/agentic-authorization-service.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { TurnContext, Authorization } from '@microsoft/agents-hosting';
-import { AgenticAuthenticationService } from '@microsoft/agents-a365-runtime';
+import { AgenticAuthenticationService, AppTokenProvider } from '@microsoft/agents-a365-runtime';
 
 describe('AgenticAuthenticationService', () => {
   let mockAuthorization: jest.Mocked<Authorization>;
@@ -116,6 +116,53 @@ describe('AgenticAuthenticationService', () => {
         mockAuthHandlerName,
         { scopes: ['ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default'] }
       );
+    });
+  });
+
+  describe('GetAgenticAppToken', () => {
+    it('should return token from the AppTokenProvider', async () => {
+      const mockProvider: AppTokenProvider = jest.fn<AppTokenProvider>().mockResolvedValue('app-token-123');
+
+      const result = await AgenticAuthenticationService.GetAgenticAppToken(
+        mockProvider,
+        ['api://test-audience/.default']
+      );
+
+      expect(result).toEqual('app-token-123');
+      expect(mockProvider).toHaveBeenCalledWith(['api://test-audience/.default']);
+    });
+
+    it('should throw when token provider returns empty string', async () => {
+      const mockProvider: AppTokenProvider = jest.fn<AppTokenProvider>().mockResolvedValue('');
+
+      await expect(
+        AgenticAuthenticationService.GetAgenticAppToken(mockProvider, ['scope/.default'])
+      ).rejects.toThrow('Client credentials token acquisition failed');
+    });
+
+    it('should throw when token provider returns null', async () => {
+      const mockProvider: AppTokenProvider = jest.fn<AppTokenProvider>().mockResolvedValue(null as unknown as string);
+
+      await expect(
+        AgenticAuthenticationService.GetAgenticAppToken(mockProvider, ['scope/.default'])
+      ).rejects.toThrow('Client credentials token acquisition failed');
+    });
+
+    it('should propagate errors from the token provider', async () => {
+      const mockProvider: AppTokenProvider = jest.fn<AppTokenProvider>().mockRejectedValue(new Error('MSAL client credentials failed'));
+
+      await expect(
+        AgenticAuthenticationService.GetAgenticAppToken(mockProvider, ['scope/.default'])
+      ).rejects.toThrow('MSAL client credentials failed');
+    });
+
+    it('should pass multiple scopes to the token provider', async () => {
+      const mockProvider: AppTokenProvider = jest.fn<AppTokenProvider>().mockResolvedValue('multi-scope-token');
+      const scopes = ['scope1/.default', 'scope2/.default'];
+
+      await AgenticAuthenticationService.GetAgenticAppToken(mockProvider, scopes);
+
+      expect(mockProvider).toHaveBeenCalledWith(scopes);
     });
   });
 });

--- a/tests/tooling/McpToolServerConfigurationService.test.ts
+++ b/tests/tooling/McpToolServerConfigurationService.test.ts
@@ -6,7 +6,7 @@ import { McpToolServerConfigurationService } from '../../packages/agents-a365-to
 import { Utility } from '../../packages/agents-a365-tooling/src/Utility';
 import { ToolingConfiguration, defaultToolingConfigurationProvider } from '../../packages/agents-a365-tooling/src/configuration';
 import { TurnContext, Authorization } from '@microsoft/agents-hosting';
-import { AgenticAuthenticationService, DefaultConfigurationProvider, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
+import { AgenticAuthenticationService, AppTokenProvider, DefaultConfigurationProvider, Utility as RuntimeUtility } from '@microsoft/agents-a365-runtime';
 import fs from 'fs';
 
 describe('McpToolServerConfigurationService', () => {
@@ -1541,6 +1541,251 @@ describe('McpToolServerConfigurationService', () => {
         const servers = await service.listToolServers('agent-id', mockToken);
 
         expect(servers[0].headers?.Authorization).toBe(`Bearer ${mockToken}`);
+      });
+    });
+  });
+
+  describe('listToolServers S2S signature (agenticAppId, tokenProvider)', () => {
+    let mockTokenProvider: jest.Mock<AppTokenProvider>;
+    let getAgenticAppTokenSpy: jest.SpiedFunction<typeof AgenticAuthenticationService.GetAgenticAppToken>;
+
+    const createMockJwt = (seed = 'default') => {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+      const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, sub: seed })).toString('base64url');
+      return `${header}.${payload}.mock-sig`;
+    };
+
+    beforeEach(() => {
+      mockTokenProvider = jest.fn<AppTokenProvider>();
+      getAgenticAppTokenSpy = jest.spyOn(AgenticAuthenticationService, 'GetAgenticAppToken');
+    });
+
+    afterEach(() => {
+      getAgenticAppTokenSpy.mockRestore();
+    });
+
+    describe('development mode (manifest)', () => {
+      beforeEach(() => {
+        process.env.NODE_ENV = 'Development';
+      });
+
+      it('should read from manifest and use dev token acquirer', async () => {
+        const manifestContent = {
+          mcpServers: [{ mcpServerName: 'testServer', url: 'http://localhost:3000' }]
+        };
+        const mockToken = createMockJwt('s2s');
+        mockTokenProvider.mockResolvedValue(mockToken);
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(manifestContent));
+
+        const servers = await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        expect(servers).toHaveLength(1);
+        expect(servers[0].mcpServerName).toBe('testServer');
+        // Dev mode uses env var acquirer, not S2S acquirer
+        expect(getAgenticAppTokenSpy).toHaveBeenCalledTimes(1); // Only for the gateway token
+      });
+
+      it('should attach BEARER_TOKEN env var in dev mode (not S2S acquirer)', async () => {
+        process.env.BEARER_TOKEN = 'dev-shared-token';
+        const manifestContent = {
+          mcpServers: [{ mcpServerName: 'testServer', url: 'http://localhost:3000' }]
+        };
+        const mockToken = createMockJwt('s2s');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(manifestContent));
+
+        const servers = await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        expect(servers[0].headers?.Authorization).toBe('Bearer dev-shared-token');
+        delete process.env.BEARER_TOKEN;
+      });
+    });
+
+    describe('production mode (gateway)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let axiosGetSpy: any;
+
+      beforeEach(() => {
+        process.env.NODE_ENV = 'production';
+        jest.spyOn(Utility, 'ValidateAuthToken').mockImplementation(() => {});
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const axios = require('axios');
+        axiosGetSpy = jest.spyOn(axios, 'get');
+      });
+
+      afterEach(() => {
+        axiosGetSpy.mockRestore();
+      });
+
+      it('should acquire gateway token via GetAgenticAppToken and call gateway', async () => {
+        const mockToken = createMockJwt('s2s-gateway');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+        axiosGetSpy.mockResolvedValue({
+          data: [{ mcpServerName: 'prodServer', url: 'http://prod.example.com' }]
+        });
+
+        await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        // Should have called GetAgenticAppToken for the gateway token
+        expect(getAgenticAppTokenSpy).toHaveBeenCalledWith(
+          mockTokenProvider,
+          ['ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default']
+        );
+
+        // Should call gateway with the correct URL
+        expect(axiosGetSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/agents/v2/my-agent-id/mcpServers'),
+          expect.any(Object)
+        );
+      });
+
+      it('should use S2S token acquirer for per-server tokens in prod', async () => {
+        const v2Audience = 'aaaabbbb-1234-5678-abcd-111122223333';
+        const gatewayToken = createMockJwt('gateway');
+        const serverToken = createMockJwt('server');
+        // First call: gateway token, second call: per-server token
+        getAgenticAppTokenSpy
+          .mockResolvedValueOnce(gatewayToken)
+          .mockResolvedValueOnce(serverToken);
+
+        axiosGetSpy.mockResolvedValue({
+          data: [{
+            mcpServerName: 'v2Server',
+            url: 'http://v2.example.com',
+            audience: v2Audience,
+            scope: 'Tools.ListInvoke.All'
+          }]
+        });
+
+        const servers = await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        // Per-server S2S token should be attached
+        expect(servers[0].headers?.Authorization).toBe(`Bearer ${serverToken}`);
+        // Second call should use per-audience scope
+        expect(getAgenticAppTokenSpy).toHaveBeenNthCalledWith(
+          2,
+          mockTokenProvider,
+          [`${v2Audience}/Tools.ListInvoke.All`]
+        );
+      });
+
+      it('should cache tokens for servers sharing the same audience', async () => {
+        const sharedAudience = 'aaaabbbb-1234-5678-abcd-111122223333';
+        const gatewayToken = createMockJwt('gateway');
+        const sharedToken = createMockJwt('shared');
+        getAgenticAppTokenSpy
+          .mockResolvedValueOnce(gatewayToken)
+          .mockResolvedValueOnce(sharedToken);
+
+        axiosGetSpy.mockResolvedValue({
+          data: [
+            { mcpServerName: 'server1', url: 'http://s1.example.com', audience: sharedAudience },
+            { mcpServerName: 'server2', url: 'http://s2.example.com', audience: sharedAudience },
+          ]
+        });
+
+        const servers = await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        // Only 2 calls: gateway + one shared per-audience token (cached for second server)
+        expect(getAgenticAppTokenSpy).toHaveBeenCalledTimes(2);
+        expect(servers[0].headers?.Authorization).toBe(`Bearer ${sharedToken}`);
+        expect(servers[1].headers?.Authorization).toBe(`Bearer ${sharedToken}`);
+      });
+
+      it('should throw when token provider fails for gateway token', async () => {
+        getAgenticAppTokenSpy.mockRejectedValue(new Error('Client credentials token acquisition failed: token provider returned an empty or null token'));
+
+        await expect(
+          service.listToolServers('my-agent-id', mockTokenProvider)
+        ).rejects.toThrow('Client credentials token acquisition failed');
+      });
+
+      it('should pass ToolOptions when provided', async () => {
+        const mockToken = createMockJwt('s2s');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+        axiosGetSpy.mockResolvedValue({ data: [] });
+
+        await service.listToolServers('my-agent-id', mockTokenProvider, undefined, { orchestratorName: 'Claude' });
+
+        expect(axiosGetSpy).toHaveBeenCalled();
+      });
+
+      it('should include x-ms-agentid header when turnContext is provided', async () => {
+        const mockToken = createMockJwt('s2s-ctx');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+        axiosGetSpy.mockResolvedValue({
+          data: [{ mcpServerName: 'prodServer', url: 'http://prod.example.com' }]
+        });
+
+        const mockContext = {
+          activity: {
+            from: { agenticAppBlueprintId: 'blueprint-s2s' },
+            channelId: 'msteams',
+            recipient: { id: 'recipient-id' },
+            conversation: { id: 'conv-id' },
+            isAgenticRequest: jest.fn().mockReturnValue(false),
+            getAgenticInstanceId: jest.fn().mockReturnValue(undefined)
+          },
+          sendActivity: jest.fn()
+        } as unknown as TurnContext;
+
+        await service.listToolServers('my-agent-id', mockTokenProvider, mockContext);
+
+        // Gateway call should include x-ms-agentid from TurnContext
+        const callArgs = axiosGetSpy.mock.calls[0] as [string, { headers: Record<string, string> }];
+        const headers = callArgs[1].headers;
+        expect(headers['x-ms-agentid']).toBe('blueprint-s2s');
+      });
+
+      it('should not include x-ms-agentid header when turnContext is omitted', async () => {
+        const mockToken = createMockJwt('s2s-no-ctx');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+        axiosGetSpy.mockResolvedValue({
+          data: [{ mcpServerName: 'prodServer', url: 'http://prod.example.com' }]
+        });
+
+        await service.listToolServers('my-agent-id', mockTokenProvider);
+
+        // Gateway call should not have x-ms-agentid
+        const callArgs = axiosGetSpy.mock.calls[0] as [string, { headers: Record<string, string> }];
+        const headers = callArgs[1].headers;
+        expect(headers['x-ms-agentid']).toBeUndefined();
+      });
+
+      it('should pass turnContext and ToolOptions together', async () => {
+        const mockToken = createMockJwt('s2s-both');
+        getAgenticAppTokenSpy.mockResolvedValue(mockToken);
+        axiosGetSpy.mockResolvedValue({
+          data: [{ mcpServerName: 'prodServer', url: 'http://prod.example.com' }]
+        });
+
+        const mockContext = {
+          activity: {
+            from: { agenticAppBlueprintId: 'blueprint-both' },
+            channelId: 'webchat',
+            recipient: { id: 'recipient-id' },
+            conversation: { id: 'conv-id' },
+            isAgenticRequest: jest.fn().mockReturnValue(false),
+            getAgenticInstanceId: jest.fn().mockReturnValue(undefined)
+          },
+          sendActivity: jest.fn()
+        } as unknown as TurnContext;
+
+        await service.listToolServers('my-agent-id', mockTokenProvider, mockContext, { orchestratorName: 'Claude' });
+
+        const callArgs = axiosGetSpy.mock.calls[0] as [string, { headers: Record<string, string> }];
+        const headers = callArgs[1].headers;
+        expect(headers['x-ms-agentid']).toBe('blueprint-both');
+        expect(axiosGetSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/agents/v2/my-agent-id/mcpServers'),
+          expect.any(Object)
+        );
       });
     });
   });

--- a/tests/tooling/McpToolServerConfigurationService.test.ts
+++ b/tests/tooling/McpToolServerConfigurationService.test.ts
@@ -1546,7 +1546,7 @@ describe('McpToolServerConfigurationService', () => {
   });
 
   describe('listToolServers S2S signature (agenticAppId, tokenProvider)', () => {
-    let mockTokenProvider: jest.Mock<AppTokenProvider>;
+    let mockTokenProvider: jest.MockedFunction<AppTokenProvider>;
     let getAgenticAppTokenSpy: jest.SpiedFunction<typeof AgenticAuthenticationService.GetAgenticAppToken>;
 
     const createMockJwt = (seed = 'default') => {
@@ -1584,8 +1584,8 @@ describe('McpToolServerConfigurationService', () => {
 
         expect(servers).toHaveLength(1);
         expect(servers[0].mcpServerName).toBe('testServer');
-        // Dev mode uses env var acquirer, not S2S acquirer
-        expect(getAgenticAppTokenSpy).toHaveBeenCalledTimes(1); // Only for the gateway token
+        // Dev mode skips gateway token acquisition
+        expect(getAgenticAppTokenSpy).not.toHaveBeenCalled();
       });
 
       it('should attach BEARER_TOKEN env var in dev mode (not S2S acquirer)', async () => {


### PR DESCRIPTION
This pull request introduces support for service-to-service (S2S) authentication using OAuth 2.0 client credentials (app-only tokens) throughout the Agentic MCP tool registration and configuration flow. It adds a new `AppTokenProvider` abstraction, updates the `AgenticAuthenticationService` and `McpToolServerConfigurationService` to support S2S flows, and extends the MCP tool registration logic in all agent tooling extensions (Claude, LangChain, OpenAI) to allow registration with either user-delegated (OBO) or app-only authentication.

Key changes:

**Service-to-Service (S2S) Authentication Enablement:**

* Introduced the `AppTokenProvider` type, a function abstraction for acquiring app-only OAuth tokens, and added the `GetAgenticAppToken` static method to `AgenticAuthenticationService` for obtaining S2S tokens using this provider. [[1]](diffhunk://#diff-e4f5b6aa5e3355dc3f3181799e0545d8c1c7d3dd95e0e9e619200c0668876803L8-R21) [[2]](diffhunk://#diff-e4f5b6aa5e3355dc3f3181799e0545d8c1c7d3dd95e0e9e619200c0668876803R66-R85)

* Updated `McpToolServerConfigurationService` with a new overload of `listToolServers` that accepts an `AppTokenProvider` for S2S authentication, including logic to acquire gateway and per-audience tokens using the client credentials flow, and a helper for S2S token acquisition. [[1]](diffhunk://#diff-7c347198ca9342e814cde9c47a7d2beb3f33b90882e39f55a0a4070b047c16e9L8-R8) [[2]](diffhunk://#diff-7c347198ca9342e814cde9c47a7d2beb3f33b90882e39f55a0a4070b047c16e9R73-R130) [[3]](diffhunk://#diff-7c347198ca9342e814cde9c47a7d2beb3f33b90882e39f55a0a4070b047c16e9L107-R163) [[4]](diffhunk://#diff-7c347198ca9342e814cde9c47a7d2beb3f33b90882e39f55a0a4070b047c16e9R296-R310)

**Agent Tool Registration Extensions:**

* Enhanced `McpToolRegistrationService` in the Claude, LangChain, and OpenAI tooling extensions to support both OBO (user) and S2S (app-only) authentication flows for registering MCP tool servers. These now accept either an `Authorization`/handler or an `agenticAppId`/`AppTokenProvider`, and call the appropriate overload of `listToolServers`. [[1]](diffhunk://#diff-5cdd2ab7f074c2652fd8523e1982fe4d3606a5ace48e020ad79e033c34d9a3bfL5-R5) [[2]](diffhunk://#diff-5cdd2ab7f074c2652fd8523e1982fe4d3606a5ace48e020ad79e033c34d9a3bfL47-R109) [[3]](diffhunk://#diff-4c2500255e4de2687e5bbd6f15ad982121c9fcad9e0419a6962e3fb4e7c2229fL5-R6) [[4]](diffhunk://#diff-4c2500255e4de2687e5bbd6f15ad982121c9fcad9e0419a6962e3fb4e7c2229fL63-R123) [[5]](diffhunk://#diff-ae96713ed280baaeb4ef497c75c3a9b318530bb5d07d3055507f9ed78b99c643L5-R6) [[6]](diffhunk://#diff-ae96713ed280baaeb4ef497c75c3a9b318530bb5d07d3055507f9ed78b99c643L51-R111)

**Internal Refactoring and Type Updates:**

* Refactored function signatures and imports across the codebase to consistently support the new authentication abstraction and to clarify the separation between OBO and S2S authentication paths. [[1]](diffhunk://#diff-5cdd2ab7f074c2652fd8523e1982fe4d3606a5ace48e020ad79e033c34d9a3bfL5-R5) [[2]](diffhunk://#diff-4c2500255e4de2687e5bbd6f15ad982121c9fcad9e0419a6962e3fb4e7c2229fL5-R6) [[3]](diffhunk://#diff-ae96713ed280baaeb4ef497c75c3a9b318530bb5d07d3055507f9ed78b99c643L5-R6) [[4]](diffhunk://#diff-7c347198ca9342e814cde9c47a7d2beb3f33b90882e39f55a0a4070b047c16e9L8-R8)

These changes collectively enable agentic tool registration and server discovery to work seamlessly with either user or app authentication, improving flexibility and supporting new service-to-service integration scenarios.