### PR TITLE
Filter A365 exports to only include genAI spans

### DIFF
--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -88,7 +88,22 @@ export function statusName(code: SpanStatusCode): string {
 }
 
 /**
- * Partition spans by (tenantId, agentId) identity pairs
+ * Known genAI operation names produced by the SDK scopes and auto-instrumentation.
+ * Only spans whose gen_ai.operation.name matches one of these values are exported.
+ */
+const GEN_AI_OPERATION_NAMES: ReadonlySet<string> = new Set([
+  OpenTelemetryConstants.INVOKE_AGENT_OPERATION_NAME,   // 'invoke_agent'
+  OpenTelemetryConstants.EXECUTE_TOOL_OPERATION_NAME,   // 'execute_tool'
+  OpenTelemetryConstants.OUTPUT_MESSAGES_OPERATION_NAME, // 'output_messages'
+  OpenTelemetryConstants.CHAT_OPERATION_NAME,            // 'chat'
+  'Chat',            // InferenceOperationType.CHAT
+  'TextCompletion',  // InferenceOperationType.TEXT_COMPLETION
+  'GenerateContent', // InferenceOperationType.GENERATE_CONTENT
+]);
+
+/**
+ * Partition spans by (tenantId, agentId) identity pairs.
+ * Only genAI spans (those with a known gen_ai.operation.name) are included.
  */
 export function partitionByIdentity(
   spans: ReadableSpan[]
@@ -102,7 +117,7 @@ export function partitionByIdentity(
     const tenant = asStr(attrs[OpenTelemetryConstants.TENANT_ID_KEY]);
     const agent = asStr(attrs[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]);
 
-    if (!operationName || !tenant || !agent) {
+    if (!operationName || !GEN_AI_OPERATION_NAMES.has(operationName) || !tenant || !agent) {
       skippedCount++;
       continue;
     }

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -97,8 +97,6 @@ const GEN_AI_OPERATION_NAMES: ReadonlySet<string> = new Set([
   OpenTelemetryConstants.OUTPUT_MESSAGES_OPERATION_NAME, // 'output_messages'
   OpenTelemetryConstants.CHAT_OPERATION_NAME,            // 'chat'
   'Chat',            // InferenceOperationType.CHAT
-  'TextCompletion',  // InferenceOperationType.TEXT_COMPLETION
-  'GenerateContent', // InferenceOperationType.GENERATE_CONTENT
 ]);
 
 /**

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -98,10 +98,11 @@ export function partitionByIdentity(
   let skippedCount = 0;
   for (const span of spans) {
     const attrs = span.attributes || {};
+    const operationName = asStr(attrs[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]);
     const tenant = asStr(attrs[OpenTelemetryConstants.TENANT_ID_KEY]);
     const agent = asStr(attrs[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]);
 
-    if (!tenant || !agent) {
+    if (!operationName || !tenant || !agent) {
       skippedCount++;
       continue;
     }
@@ -113,7 +114,7 @@ export function partitionByIdentity(
   }
 
   if(skippedCount > 0) {
-    logger.event(ExporterEventNames.EXPORT_PARTITION_SPAN_MISSING_IDENTITY, false, 0, `${skippedCount} spans are skipped due to missing tenant or agent ID`);
+    logger.event(ExporterEventNames.EXPORT_PARTITION_SPAN_MISSING_IDENTITY, false, 0, `${skippedCount} spans are skipped due to missing genAI operation name, tenant, or agent ID`);
   }
 
   logger.info(`[Agent365Exporter] Partitioned into ${groups.size} identity groups (${skippedCount} spans skipped)`);

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -108,15 +108,22 @@ export function partitionByIdentity(
 ): Map<string, ReadableSpan[]> {
   const groups = new Map<string, ReadableSpan[]>();
 
-  let skippedCount = 0;
+  let nonGenAICount = 0;
+  let missingIdentityCount = 0;
   for (const span of spans) {
     const attrs = span.attributes || {};
     const operationName = asStr(attrs[OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]);
+
+    if (!operationName || !GEN_AI_OPERATION_NAMES.has(operationName)) {
+      nonGenAICount++;
+      continue;
+    }
+
     const tenant = asStr(attrs[OpenTelemetryConstants.TENANT_ID_KEY]);
     const agent = asStr(attrs[OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]);
 
-    if (!operationName || !GEN_AI_OPERATION_NAMES.has(operationName) || !tenant || !agent) {
-      skippedCount++;
+    if (!tenant || !agent) {
+      missingIdentityCount++;
       continue;
     }
 
@@ -126,10 +133,15 @@ export function partitionByIdentity(
     groups.set(key, existing);
   }
 
-  if(skippedCount > 0) {
-    logger.event(ExporterEventNames.EXPORT_PARTITION_SPAN_MISSING_IDENTITY, false, 0, `${skippedCount} spans are skipped due to missing genAI operation name, tenant, or agent ID`);
+  if (nonGenAICount > 0) {
+    logger.info(`[Agent365Exporter] ${nonGenAICount} non-genAI spans filtered out`);
   }
 
+  if (missingIdentityCount > 0) {
+    logger.event(ExporterEventNames.EXPORT_PARTITION_SPAN_MISSING_IDENTITY, false, 0, `${missingIdentityCount} spans are skipped due to missing tenant or agent ID`);
+  }
+
+  const skippedCount = nonGenAICount + missingIdentityCount;
   logger.info(`[Agent365Exporter] Partitioned into ${groups.size} identity groups (${skippedCount} spans skipped)`);
   return groups;
 }

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -97,6 +97,8 @@ const GEN_AI_OPERATION_NAMES: ReadonlySet<string> = new Set([
   OpenTelemetryConstants.OUTPUT_MESSAGES_OPERATION_NAME, // 'output_messages'
   OpenTelemetryConstants.CHAT_OPERATION_NAME,            // 'chat'
   'Chat',            // InferenceOperationType.CHAT
+  'TextCompletion',  // InferenceOperationType.TEXT_COMPLETION
+  'GenerateContent', // InferenceOperationType.GENERATE_CONTENT
 ]);
 
 /**

--- a/tests/observability/core/agent365-exporter.test.ts
+++ b/tests/observability/core/agent365-exporter.test.ts
@@ -26,7 +26,10 @@ function makeSpan(attrs: Record<string, unknown>, name = 'test'): ReadableSpan {
     startTime: [Math.floor(Date.now() / 1000), 0],
     endTime: [Math.floor(Date.now() / 1000) + 1, 0],
     status: { code: 0 },
-    attributes: attrs,
+    attributes: {
+      [OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]: 'invoke_agent',
+      ...attrs,
+    },
     events: [],
     links: [],
     duration: [1, 0],

--- a/tests/observability/tracing/exporter-utils.test.ts
+++ b/tests/observability/tracing/exporter-utils.test.ts
@@ -480,7 +480,7 @@ describe('exporter/utils', () => {
       expect(result.size).toBe(0);
     });
 
-    it('should skip spans without a known gen_ai.operation.name', async () => {
+    it('should skip spans with missing or unknown gen_ai.operation.name', async () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [

--- a/tests/observability/tracing/exporter-utils.test.ts
+++ b/tests/observability/tracing/exporter-utils.test.ts
@@ -387,7 +387,7 @@ describe('exporter/utils', () => {
   });
 
   describe('partitionByIdentity', () => {
-    const createMockSpan = (name: string, tenantId?: string, agentId?: string): ReadableSpan => ({
+    const createMockSpan = (name: string, tenantId?: string, agentId?: string, operationName?: string): ReadableSpan => ({
       name,
       kind: SpanKind.INTERNAL,
       spanContext: () => ({
@@ -402,6 +402,7 @@ describe('exporter/utils', () => {
       attributes: {
         ...(tenantId !== undefined && { [OpenTelemetryConstants.TENANT_ID_KEY]: tenantId }),
         ...(agentId !== undefined && { [OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY]: agentId }),
+        ...(operationName !== undefined && { [OpenTelemetryConstants.GEN_AI_OPERATION_NAME_KEY]: operationName }),
       },
       links: [],
       events: [],
@@ -417,9 +418,9 @@ describe('exporter/utils', () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [
-        createMockSpan('span1', 'tenant1', 'agent1'),
-        createMockSpan('span2', 'tenant1', 'agent1'),
-        createMockSpan('span3', 'tenant2', 'agent2'),
+        createMockSpan('span1', 'tenant1', 'agent1', 'invoke_agent'),
+        createMockSpan('span2', 'tenant1', 'agent1', 'chat'),
+        createMockSpan('span3', 'tenant2', 'agent2', 'execute_tool'),
       ];
 
       const result = partitionByIdentity(spans);
@@ -433,8 +434,8 @@ describe('exporter/utils', () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [
-        createMockSpan('span1', undefined, 'agent1'),
-        createMockSpan('span2', 'tenant1', 'agent1'),
+        createMockSpan('span1', undefined, 'agent1', 'invoke_agent'),
+        createMockSpan('span2', 'tenant1', 'agent1', 'invoke_agent'),
       ];
 
       const result = partitionByIdentity(spans);
@@ -447,8 +448,8 @@ describe('exporter/utils', () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [
-        createMockSpan('span1', 'tenant1', undefined),
-        createMockSpan('span2', 'tenant1', 'agent1'),
+        createMockSpan('span1', 'tenant1', undefined, 'invoke_agent'),
+        createMockSpan('span2', 'tenant1', 'agent1', 'invoke_agent'),
       ];
 
       const result = partitionByIdentity(spans);
@@ -469,14 +470,30 @@ describe('exporter/utils', () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [
-        createMockSpan('span1', undefined, undefined),
-        createMockSpan('span2', 'tenant1', undefined),
-        createMockSpan('span3', undefined, 'agent1'),
+        createMockSpan('span1', undefined, undefined, 'invoke_agent'),
+        createMockSpan('span2', 'tenant1', undefined, 'invoke_agent'),
+        createMockSpan('span3', undefined, 'agent1', 'invoke_agent'),
       ];
 
       const result = partitionByIdentity(spans);
 
       expect(result.size).toBe(0);
+    });
+
+    it('should skip spans without gen_ai.operation.name', async () => {
+      const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
+
+      const spans = [
+        createMockSpan('genai-span', 'tenant1', 'agent1', 'invoke_agent'),
+        createMockSpan('http-span', 'tenant1', 'agent1', undefined),
+        createMockSpan('db-span', 'tenant1', 'agent1'),
+      ];
+
+      const result = partitionByIdentity(spans);
+
+      expect(result.size).toBe(1);
+      expect(result.get('tenant1:agent1')?.length).toBe(1);
+      expect(result.get('tenant1:agent1')?.[0].name).toBe('genai-span');
     });
   });
 });

--- a/tests/observability/tracing/exporter-utils.test.ts
+++ b/tests/observability/tracing/exporter-utils.test.ts
@@ -480,13 +480,14 @@ describe('exporter/utils', () => {
       expect(result.size).toBe(0);
     });
 
-    it('should skip spans without gen_ai.operation.name', async () => {
+    it('should skip spans without a known gen_ai.operation.name', async () => {
       const { partitionByIdentity } = await import('@microsoft/agents-a365-observability/src/tracing/exporter/utils');
 
       const spans = [
         createMockSpan('genai-span', 'tenant1', 'agent1', 'invoke_agent'),
         createMockSpan('http-span', 'tenant1', 'agent1', undefined),
         createMockSpan('db-span', 'tenant1', 'agent1'),
+        createMockSpan('unknown-op', 'tenant1', 'agent1', 'some_random_op'),
       ];
 
       const result = partitionByIdentity(spans);


### PR DESCRIPTION
## Summary
- Adds a `gen_ai.operation.name` attribute check in `partitionByIdentity()` so the A365 exporter only exports genAI spans (invoke_agent, chat, execute_tool, output_messages, etc.) and filters out non-genAI spans (HTTP, DB, etc.) from other instrumentations.
- Updates log message to reflect the additional filter criterion.

## Test plan
- [x] New test: `should skip spans without gen_ai.operation.name` validates non-genAI spans are filtered
- [x] Existing partition tests updated and passing
- [x] Full `pnpm test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)