### PR TITLE
fix: stabilize ObservabilityBuilder serviceNamespace test

### DIFF
--- a/tests/observability/core/observabilityBuilder-options.test.ts
+++ b/tests/observability/core/observabilityBuilder-options.test.ts
@@ -4,7 +4,7 @@
 import { ObservabilityBuilder } from '@microsoft/agents-a365-observability/src/ObservabilityBuilder';
 import { ClusterCategory } from '@microsoft/agents-a365-runtime';
 import { ATTR_SERVICE_NAMESPACE } from '@opentelemetry/semantic-conventions';
-import * as resources from '@opentelemetry/resources';
+import { trace } from '@opentelemetry/api';
 
 // Mock the Agent365Exporter so we can capture the constructed options without performing network calls.
 jest.mock('@microsoft/agents-a365-observability/src/tracing/exporter/Agent365Exporter', () => {
@@ -79,19 +79,33 @@ describe('ObservabilityBuilder exporterOptions merging', () => {
 });
 
 describe('ObservabilityBuilder serviceNamespace', () => {
-  it('includes service.namespace only when withServiceNamespace is called', () => {
-    const resourceSpy = jest.spyOn(resources, 'resourceFromAttributes');
+  let createResourceSpy: jest.SpyInstance;
+
+  beforeEach(() => {
     process.env.ENABLE_A365_OBSERVABILITY_EXPORTER = 'true';
+    // Spy on the private createResource method to capture the resource attributes.
+    createResourceSpy = jest.spyOn(ObservabilityBuilder.prototype as any, 'createResource');
+    // Force the builder to take the NodeSDK code path (which calls createResource)
+    // by making getTracerProvider return a provider without addSpanProcessor/resource.
+    jest.spyOn(trace, 'getTracerProvider').mockReturnValue({} as any);
+  });
 
-    // Without namespace
-    new ObservabilityBuilder().withService('svc').build();
-    expect(resourceSpy.mock.calls[0][0]).not.toHaveProperty(ATTR_SERVICE_NAMESPACE);
-
-    // With namespace
-    new ObservabilityBuilder().withService('svc').withServiceNamespace('ns').build();
-    expect(resourceSpy.mock.calls[1][0][ATTR_SERVICE_NAMESPACE]).toBe('ns');
-
+  afterEach(() => {
     delete process.env.ENABLE_A365_OBSERVABILITY_EXPORTER;
-    resourceSpy.mockRestore();
+  });
+
+  it('does not include service.namespace when withServiceNamespace is not called', () => {
+    new ObservabilityBuilder().withService('svc').build();
+    expect(createResourceSpy).toHaveBeenCalled();
+    const result = createResourceSpy.mock.results[0].value;
+    // The resource should not contain ATTR_SERVICE_NAMESPACE
+    expect(result?.attributes?.[ATTR_SERVICE_NAMESPACE]).toBeUndefined();
+  });
+
+  it('includes service.namespace when withServiceNamespace is called', () => {
+    new ObservabilityBuilder().withService('svc').withServiceNamespace('ns').build();
+    expect(createResourceSpy).toHaveBeenCalled();
+    const result = createResourceSpy.mock.results[0].value;
+    expect(result?.attributes?.[ATTR_SERVICE_NAMESPACE]).toBe('ns');
   });
 });


### PR DESCRIPTION
## Summary
- Fixed flaky `observabilityBuilder-options.test.ts` serviceNamespace test that failed because prior tests registered a global tracer provider, causing `build()` to skip `createResource()`
- Replaced broken `resourceFromAttributes` spy (which targeted the root `@opentelemetry/resources` while the builder resolved a nested copy) with a `createResource` prototype spy
- Split single combined test into two independent tests with proper `beforeEach`/`afterEach` lifecycle, mocking `getTracerProvider` to force the NodeSDK code path

## Test plan
- [x] `observabilityBuilder-options.test.ts` — all 4 tests pass (2 exporterOptions + 2 serviceNamespace)
- [x] Full test suite — 1239 tests pass; only pre-existing `agentic-token-cache.test.ts` TS error remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)