### PR TITLE
Bump version to 1.0 for stable release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2.0-preview.{height}",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/master$",


### PR DESCRIPTION
Updated version.json to set the version number from "0.2.0-preview.{height}" to "1.0", marking the transition from a preview to the first stable release.