### PR TITLE
fix: add product context fallback for subchannel

### DIFF
--- a/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
+++ b/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
@@ -103,8 +103,8 @@ export function getChannelBaggagePairs(turnContext: TurnContext): Array<[string,
   
   let subChannel = turnContext.activity?.channelIdSubChannel as string | undefined;
   
-  // Try to get subChannel from productContext in channelData if subChannel is not set
-  if (!subChannel && turnContext.activity?.channelData) {
+  // Try to get subChannel from productContext in channelData if subChannel is not set or empty
+  if ((!subChannel || subChannel.trim() === '') && turnContext.activity?.channelData) {
     try {
       const channelData = turnContext.activity.channelData;
       let channelDataObj: Record<string, unknown> | undefined;

--- a/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
+++ b/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
@@ -99,10 +99,35 @@ export function getTenantIdPair(turnContext: TurnContext): Array<[string, string
 export function getChannelBaggagePairs(turnContext: TurnContext): Array<[string, string]> {
   if (!turnContext) { 
     return [];
-  }  
+  }
+  
+  let subChannel = turnContext.activity?.channelIdSubChannel as string | undefined;
+  
+  // Try to get subChannel from productContext in channelData if subChannel is not set
+  if (!subChannel && turnContext.activity?.channelData) {
+    try {
+      const channelData = turnContext.activity.channelData;
+      let channelDataObj: any;
+      
+      // Convert channelData to object if it's a string
+      if (typeof channelData === 'string') {
+        channelDataObj = JSON.parse(channelData);
+      } else if (typeof channelData === 'object') {
+        channelDataObj = channelData;
+      }
+      
+      // Extract productContext if available
+      if (channelDataObj && typeof channelDataObj.productContext === 'string') {
+        subChannel = channelDataObj.productContext;
+      }
+    } catch {
+      // Silently ignore any parsing errors
+    }
+  }
+  
   const pairs: Array<[string, string | undefined]> = [
     [OpenTelemetryConstants.CHANNEL_NAME_KEY, turnContext.activity?.channelId],
-    [OpenTelemetryConstants.CHANNEL_LINK_KEY, turnContext.activity?.channelIdSubChannel as string | undefined]
+    [OpenTelemetryConstants.CHANNEL_LINK_KEY, subChannel]
   ];
   return normalizePairs(pairs);
 }

--- a/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
+++ b/packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.ts
@@ -107,13 +107,13 @@ export function getChannelBaggagePairs(turnContext: TurnContext): Array<[string,
   if (!subChannel && turnContext.activity?.channelData) {
     try {
       const channelData = turnContext.activity.channelData;
-      let channelDataObj: any;
+      let channelDataObj: Record<string, unknown> | undefined;
       
       // Convert channelData to object if it's a string
       if (typeof channelData === 'string') {
         channelDataObj = JSON.parse(channelData);
       } else if (typeof channelData === 'object') {
-        channelDataObj = channelData;
+        channelDataObj = channelData as Record<string, unknown>;
       }
       
       // Extract productContext if available

--- a/tests/observability/extension/hosting/baggage-middleware.test.ts
+++ b/tests/observability/extension/hosting/baggage-middleware.test.ts
@@ -183,4 +183,47 @@ describe('BaggageMiddleware', () => {
     // channelIdSubChannel should take precedence, productContext should be ignored
     expect(capturedChannelLink).toBe('teams-subchannel');
   });
+
+  it('should extract productContext from channelData when it is a JSON string', async () => {
+    const middleware = new BaggageMiddleware();
+    const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
+    
+    // Set channelData as a JSON string (simulating wire format)
+    ctx.activity.channelIdSubChannel = undefined;
+    ctx.activity.channelData = JSON.stringify({ productContext: 'COPILOT' });
+    
+    let capturedChannelLink: string | undefined;
+
+    await middleware.onTurn(ctx, async () => {
+      const bag = propagation.getBaggage(otelContext.active());
+      if (bag) {
+        const entry = bag.getEntry(OpenTelemetryConstants.CHANNEL_LINK_KEY);
+        capturedChannelLink = entry?.value;
+      }
+    });
+
+    expect(capturedChannelLink).toBe('COPILOT');
+  });
+
+  it('should handle invalid JSON channelData gracefully without setting baggage', async () => {
+    const middleware = new BaggageMiddleware();
+    const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
+    
+    // Set channelData as an invalid JSON string
+    ctx.activity.channelIdSubChannel = undefined;
+    ctx.activity.channelData = 'not valid json';
+    
+    let capturedChannelLink: string | undefined;
+
+    await middleware.onTurn(ctx, async () => {
+      const bag = propagation.getBaggage(otelContext.active());
+      if (bag) {
+        const entry = bag.getEntry(OpenTelemetryConstants.CHANNEL_LINK_KEY);
+        capturedChannelLink = entry?.value;
+      }
+    });
+
+    // Should not set ChannelLink, should fail gracefully
+    expect(capturedChannelLink).toBeUndefined();
+  });
 });

--- a/tests/observability/extension/hosting/baggage-middleware.test.ts
+++ b/tests/observability/extension/hosting/baggage-middleware.test.ts
@@ -140,4 +140,47 @@ describe('BaggageMiddleware', () => {
 
     expect(nextCalled).toBe(true);
   });
+
+  it('should extract productContext from channelData when channelIdSubChannel is not set', async () => {
+    const middleware = new BaggageMiddleware();
+    const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
+    
+    // Add channelData with productContext, no channelIdSubChannel
+    ctx.activity.channelData = { productContext: 'COPILOT' };
+    ctx.activity.channelIdSubChannel = undefined;
+    
+    let capturedChannelLink: string | undefined;
+
+    await middleware.onTurn(ctx, async () => {
+      const bag = propagation.getBaggage(otelContext.active());
+      if (bag) {
+        const entry = bag.getEntry(OpenTelemetryConstants.CHANNEL_LINK_KEY);
+        capturedChannelLink = entry?.value;
+      }
+    });
+
+    expect(capturedChannelLink).toBe('COPILOT');
+  });
+
+  it('should use channelIdSubChannel when both channelIdSubChannel and productContext are present', async () => {
+    const middleware = new BaggageMiddleware();
+    const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
+    
+    // Set BOTH channelIdSubChannel and productContext in channelData
+    ctx.activity.channelIdSubChannel = 'teams-subchannel';
+    ctx.activity.channelData = { productContext: 'COPILOT' };
+    
+    let capturedChannelLink: string | undefined;
+
+    await middleware.onTurn(ctx, async () => {
+      const bag = propagation.getBaggage(otelContext.active());
+      if (bag) {
+        const entry = bag.getEntry(OpenTelemetryConstants.CHANNEL_LINK_KEY);
+        capturedChannelLink = entry?.value;
+      }
+    });
+
+    // channelIdSubChannel should take precedence, productContext should be ignored
+    expect(capturedChannelLink).toBe('teams-subchannel');
+  });
 });

--- a/tests/observability/extension/hosting/baggage-middleware.test.ts
+++ b/tests/observability/extension/hosting/baggage-middleware.test.ts
@@ -144,11 +144,11 @@ describe('BaggageMiddleware', () => {
   it('should extract productContext from channelData when channelIdSubChannel is not set', async () => {
     const middleware = new BaggageMiddleware();
     const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
-    
+
     // Add channelData with productContext, no channelIdSubChannel
     ctx.activity.channelData = { productContext: 'COPILOT' };
     ctx.activity.channelIdSubChannel = undefined;
-    
+
     let capturedChannelLink: string | undefined;
 
     await middleware.onTurn(ctx, async () => {
@@ -165,11 +165,11 @@ describe('BaggageMiddleware', () => {
   it('should use channelIdSubChannel when both channelIdSubChannel and productContext are present', async () => {
     const middleware = new BaggageMiddleware();
     const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
-    
+
     // Set BOTH channelIdSubChannel and productContext in channelData
     ctx.activity.channelIdSubChannel = 'teams-subchannel';
     ctx.activity.channelData = { productContext: 'COPILOT' };
-    
+
     let capturedChannelLink: string | undefined;
 
     await middleware.onTurn(ctx, async () => {
@@ -187,11 +187,11 @@ describe('BaggageMiddleware', () => {
   it('should extract productContext from channelData when it is a JSON string', async () => {
     const middleware = new BaggageMiddleware();
     const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
-    
+
     // Set channelData as a JSON string (simulating wire format)
     ctx.activity.channelIdSubChannel = undefined;
     ctx.activity.channelData = JSON.stringify({ productContext: 'COPILOT' });
-    
+
     let capturedChannelLink: string | undefined;
 
     await middleware.onTurn(ctx, async () => {
@@ -205,14 +205,14 @@ describe('BaggageMiddleware', () => {
     expect(capturedChannelLink).toBe('COPILOT');
   });
 
-  it('should handle invalid JSON channelData gracefully without setting baggage', async () => {
+  it('should not set channel link when channelData is invalid JSON', async () => {
     const middleware = new BaggageMiddleware();
     const ctx: any = makeMockTurnContext({ channelId: 'msteams' });
-    
+
     // Set channelData as an invalid JSON string
     ctx.activity.channelIdSubChannel = undefined;
     ctx.activity.channelData = 'not valid json';
-    
+
     let capturedChannelLink: string | undefined;
 
     await middleware.onTurn(ctx, async () => {
@@ -223,7 +223,7 @@ describe('BaggageMiddleware', () => {
       }
     });
 
-    // Should not set ChannelLink, should fail gracefully
+    // Channel link should not be set when JSON parsing fails
     expect(capturedChannelLink).toBeUndefined();
   });
 });


### PR DESCRIPTION
Previously, when the subchannel was being sent via the `productContext` property, it was not set correctly by the SDK. This fixes a bug where having `productContext`=`"COPILOT"` was causing issues with the agent activity view.

This pull request enhances the extraction logic for channel metadata in the observability hosting utilities and adds comprehensive tests to ensure correct behavior. The main improvement is to ensure that the `productContext` field from `channelData` is used as a fallback for `channelIdSubChannel` when the latter is not set, improving robustness in channel identification.

**Channel metadata extraction improvements:**

* Updated `getChannelBaggagePairs` in `TurnContextUtils.ts` to extract `subChannel` from `productContext` in `channelData` if `channelIdSubChannel` is not set, including safe parsing of `channelData` when it's a string. (`[packages/agents-a365-observability-hosting/src/utils/TurnContextUtils.tsR103-R130](diffhunk://#diff-112092129e451c5bdec1315001940704ec79ea745988cbcdc83aea7b5cf485a2R103-R130)`)

**Test coverage enhancements:**

* Added tests to `baggage-middleware.test.ts` to verify:
  - Extraction of `productContext` from `channelData` when `channelIdSubChannel` is missing.
  - Precedence of `channelIdSubChannel` over `productContext` when both are present. (`[tests/observability/extension/hosting/baggage-middleware.test.tsR143-R185](diffhunk://#diff-dd5f4f01750f559bf2297eca7b73f062d5e37849fc73a568af42694f6b0c6e05R143-R185)`)