### PR TITLE
[nodejs]Update message format to align with OTel spec

### DIFF
--- a/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-langchain/src/Utils.ts
@@ -7,7 +7,6 @@ import {
   OpenTelemetryConstants,
   serializeMessages,
   safeSerializeToJson,
-  A365_MESSAGE_SCHEMA_VERSION,
   MessageRole,
 } from "@microsoft/agents-a365-observability";
 import type {
@@ -114,7 +113,7 @@ export function setInputMessagesAttribute(run: Run, span: Span) {
   }
 
   if (chatMessages.length > 0) {
-    const wrapper: InputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: chatMessages };
+    const wrapper: InputMessages = { messages: chatMessages };
     span.setAttribute(OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, serializeMessages(wrapper));
   }
 }
@@ -390,7 +389,7 @@ export function setOutputMessagesAttribute(run: Run, span: Span) {
   }
 
   if (outputMessages.length > 0) {
-    const wrapper: OutputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: outputMessages };
+    const wrapper: OutputMessages = { messages: outputMessages };
     span.setAttribute(OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY, serializeMessages(wrapper));
   }
 }

--- a/packages/agents-a365-observability-extensions-openai/src/Utils.ts
+++ b/packages/agents-a365-observability-extensions-openai/src/Utils.ts
@@ -7,7 +7,7 @@ import {
   OpenTelemetryConstants,
   serializeMessages,
   safeSerializeToJson,
-  A365_MESSAGE_SCHEMA_VERSION,
+  DEFAULT_FINISH_REASON,
   MessageRole,
   InputMessages,
   OutputMessages,
@@ -290,8 +290,7 @@ function getToolCallId(block: Record<string, unknown>): string | undefined {
 function wrapRawContentAsMessages(raw: unknown, role: MessageRole): InputMessages | OutputMessages {
   const content = typeof raw === 'string' ? raw : safeJsonDumps(raw);
   return {
-    version: A365_MESSAGE_SCHEMA_VERSION,
-    messages: [{ role, parts: [{ type: 'text', content }] }],
+    messages: [{ role, parts: [{ type: 'text', content }], finish_reason: role === MessageRole.ASSISTANT ? DEFAULT_FINISH_REASON : undefined }],
   };
 }
 
@@ -385,7 +384,7 @@ export function buildStructuredInputMessages(
     messages.push({ role, parts });
   }
 
-  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+  return { messages };
 }
 
 /**
@@ -422,7 +421,7 @@ export function buildStructuredOutputMessages(
     });
   }
 
-  return { version: A365_MESSAGE_SCHEMA_VERSION, messages };
+  return { messages };
 }
 
 /**

--- a/packages/agents-a365-observability/src/index.ts
+++ b/packages/agents-a365-observability/src/index.ts
@@ -69,7 +69,7 @@ export {
   InputMessagesParam,
   OutputMessagesParam,
   ResponseMessagesParam,
-  A365_MESSAGE_SCHEMA_VERSION,
+  DEFAULT_FINISH_REASON,
   GuardrailDecisionType,
   GuardrailDetails,
   GuardrailFinding,

--- a/packages/agents-a365-observability/src/tracing/contracts.ts
+++ b/packages/agents-a365-observability/src/tracing/contracts.ts
@@ -433,27 +433,27 @@ export interface ChatMessage {
 }
 
 export interface InputMessages {
-  version: typeof A365_MESSAGE_SCHEMA_VERSION;
   messages: ChatMessage[];
 }
 /**
  * An output message produced by a model (OTEL gen-ai semantic conventions).
+ * `finish_reason` defaults to `"stop"` per OTel spec when not provided.
  */
 export interface OutputMessage extends ChatMessage {
   finish_reason?: FinishReason | string;
 }
 
 export interface OutputMessages {
-  version: typeof A365_MESSAGE_SCHEMA_VERSION;
   messages: OutputMessage[];
 }
 
-export const A365_MESSAGE_SCHEMA_VERSION = '0.1.0' as const;
+/** Default finish reason applied when none is provided (per OTel spec). */
+export const DEFAULT_FINISH_REASON = 'stop' as const;
 
-/** Accepted input for `recordInputMessages`. Supports a single string, an array of strings (backward compat), or the versioned wrapper. */
+/** Accepted input for `recordInputMessages`. Supports a single string, an array of strings (backward compat), or the structured wrapper. */
 export type InputMessagesParam = string | string[] | InputMessages;
 
-/** Accepted input for `recordOutputMessages`. Supports a single string, an array of strings (backward compat), or the versioned wrapper. */
+/** Accepted input for `recordOutputMessages`. Supports a single string, an array of strings (backward compat), or the structured wrapper. */
 export type OutputMessagesParam = string | string[] | OutputMessages;
 
 /**

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -248,8 +248,7 @@ function serializeOverflowSentinel(totalMessages: number): string {
           type: 'text',
           content: `[truncated: ${totalMessages} ${totalMessages === 1 ? 'message' : 'messages'} exceeded limit]`
         }
-      ],
-      finish_reason: 'error'
+      ]
     }
   ]);
 }

--- a/packages/agents-a365-observability/src/tracing/exporter/utils.ts
+++ b/packages/agents-a365-observability/src/tracing/exporter/utils.ts
@@ -5,7 +5,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { ClusterCategory, IConfigurationProvider } from '@microsoft/agents-a365-runtime';
 import { OpenTelemetryConstants } from '../constants';
-import { A365_MESSAGE_SCHEMA_VERSION, MessageRole } from '../contracts';
+import { MessageRole } from '../contracts';
 import logger from '../../utils/logging';
 import { ExporterEventNames } from './ExporterEventNames';
 import {
@@ -236,24 +236,22 @@ const TRUNCATED_SUFFIX_BYTES = Buffer.byteLength(TRUNCATED_SUFFIX, 'utf8');
 const OVERLIMIT_SENTINEL = '[overlimit]';
 
 /**
- * Build a versioned message wrapper indicating the original messages were dropped
+ * Build a sentinel message array indicating the original messages were dropped
  * because the span exceeded the size limit.
  */
 function serializeOverflowSentinel(totalMessages: number): string {
-  return JSON.stringify({
-    version: A365_MESSAGE_SCHEMA_VERSION,
-    messages: [
-      {
-        role: MessageRole.SYSTEM,
-        parts: [
-          {
-            type: 'text',
-            content: `[truncated: ${totalMessages} ${totalMessages === 1 ? 'message' : 'messages'} exceeded limit]`
-          }
-        ]
-      }
-    ]
-  });
+  return JSON.stringify([
+    {
+      role: MessageRole.SYSTEM,
+      parts: [
+        {
+          type: 'text',
+          content: `[truncated: ${totalMessages} ${totalMessages === 1 ? 'message' : 'messages'} exceeded limit]`
+        }
+      ],
+      finish_reason: 'error'
+    }
+  ]);
 }
 
 /** Strings shorter than this (in UTF-8 bytes) are not worth truncating. */
@@ -342,7 +340,7 @@ function createBlobShrinkAction(part: Record<string, unknown>, sourceKey?: strin
  */
 function collectShrinkActions(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
 ): ShrinkAction[] {
   const actions: ShrinkAction[] = [];
 
@@ -354,8 +352,8 @@ function collectShrinkActions(
       if (!parsedMessages.has(key) && typeof attributes[key] === 'string') {
         try {
           const parsed = JSON.parse(attributes[key] as string);
-          if (parsed && typeof parsed === 'object' && typeof parsed.version === 'string' && Array.isArray(parsed.messages)) {
-            parsedMessages.set(key, parsed);
+          if (Array.isArray(parsed)) {
+            parsedMessages.set(key, { messages: parsed });
           }
         } catch {
           // Not valid JSON — will fall through to string trim
@@ -464,11 +462,11 @@ function collectShrinkActions(
 
 function flushParsedMessages(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
 ): void {
   for (const [key, wrapper] of parsedMessages) {
     try {
-      attributes[key] = JSON.stringify(wrapper);
+      attributes[key] = JSON.stringify(wrapper.messages);
     } catch {
       // Leave the previous string value intact if serialization fails.
     }
@@ -477,13 +475,13 @@ function flushParsedMessages(
 
 function flushParsedMessage(
   attributes: Record<string, unknown>,
-  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
   key: string,
 ): void {
   const wrapper = parsedMessages.get(key);
   if (wrapper) {
     try {
-      attributes[key] = JSON.stringify(wrapper);
+      attributes[key] = JSON.stringify(wrapper.messages);
     } catch {
       // Leave the previous string value intact if serialization fails.
     }
@@ -493,7 +491,7 @@ function flushParsedMessage(
 function runShrinkPhase(
   span: OTLPSpanLike,
   attributes: Record<string, unknown>,
-  parsedMessages: Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
+  parsedMessages: Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>,
   currentSize: number,
 ): number {
   let nextSize = currentSize;
@@ -679,7 +677,7 @@ export function truncateSpan<T extends OTLPSpanLike>(spanDict: T): T {
     const attributes = truncated.attributes;
     if (!attributes) return truncated;
 
-    const parsedMessages = new Map<string, { version: string; messages: Array<{ parts: Array<Record<string, unknown>> }> }>();
+    const parsedMessages = new Map<string, { messages: Array<{ parts: Array<Record<string, unknown>> }> }>();
 
     // Phase 1: iteratively shrink all fields by size priority
     currentSize = runShrinkPhase(truncated, attributes, parsedMessages, currentSize);
@@ -702,8 +700,8 @@ export function truncateSpan<T extends OTLPSpanLike>(spanDict: T): T {
             // Attempt to derive count from current attribute value
             try {
               const parsed = JSON.parse(attributes[key] as string);
-              if (parsed && typeof parsed === 'object' && typeof parsed.version === 'string' && Array.isArray(parsed.messages)) {
-                messageCount = parsed.messages.length;
+              if (Array.isArray(parsed)) {
+                messageCount = parsed.length;
               }
             } catch { /* not valid JSON — count stays 0 */ }
           }

--- a/packages/agents-a365-observability/src/tracing/message-utils.ts
+++ b/packages/agents-a365-observability/src/tracing/message-utils.ts
@@ -88,8 +88,7 @@ export function serializeMessages(wrapper: InputMessages | OutputMessages): stri
             type: 'text',
             content: `[serialization failed: ${wrapper.messages.length} ${wrapper.messages.length === 1 ? 'message' : 'messages'}]`
           }
-        ],
-        finish_reason: 'error'
+        ]
       }
     ]);
   }

--- a/packages/agents-a365-observability/src/tracing/message-utils.ts
+++ b/packages/agents-a365-observability/src/tracing/message-utils.ts
@@ -9,15 +9,15 @@ import {
   OutputMessages,
   InputMessagesParam,
   OutputMessagesParam,
-  A365_MESSAGE_SCHEMA_VERSION
+  DEFAULT_FINISH_REASON
 } from './contracts';
 
 /**
- * Type guard that returns `true` when the input is a versioned wrapper
+ * Type guard that returns `true` when the input is a structured wrapper
  * object (`InputMessages` or `OutputMessages`).
  */
 export function isWrappedMessages(input: InputMessagesParam | OutputMessagesParam): input is InputMessages | OutputMessages {
-  return !Array.isArray(input) && typeof input === 'object' && input !== null && 'version' in input && 'messages' in input;
+  return !Array.isArray(input) && typeof input === 'object' && input !== null && 'messages' in input && Array.isArray((input as InputMessages).messages);
 }
 
 /**
@@ -32,65 +32,65 @@ export function toInputMessages(messages: string[]): ChatMessage[] {
 
 /**
  * Converts plain output strings into OTEL output messages.
+ * `finish_reason` defaults to `"stop"` per OTel spec.
  */
 export function toOutputMessages(messages: string[]): OutputMessage[] {
   return messages.map((content) => ({
     role: MessageRole.ASSISTANT,
-    parts: [{ type: 'text' as const, content }]
+    parts: [{ type: 'text' as const, content }],
+    finish_reason: DEFAULT_FINISH_REASON
   }));
 }
 
 /**
- * Normalizes an `InputMessagesParam` to a versioned `InputMessages` wrapper.
+ * Normalizes an `InputMessagesParam` to an `InputMessages` instance.
  * - `string` / `string[]` → converted to `ChatMessage[]` and wrapped
  * - `InputMessages` → returned as-is
  */
 export function normalizeInputMessages(param: InputMessagesParam): InputMessages {
   if (typeof param === 'string' || Array.isArray(param)) {
     const arr = typeof param === 'string' ? [param] : param;
-    return { version: A365_MESSAGE_SCHEMA_VERSION, messages: toInputMessages(arr) };
+    return { messages: toInputMessages(arr) };
   }
   return param;
 }
 
 /**
- * Normalizes an `OutputMessagesParam` to a versioned `OutputMessages` wrapper.
+ * Normalizes an `OutputMessagesParam` to an `OutputMessages` instance.
  * - `string` / `string[]` → converted to `OutputMessage[]` and wrapped
  * - `OutputMessages` → returned as-is
  */
 export function normalizeOutputMessages(param: OutputMessagesParam): OutputMessages {
   if (typeof param === 'string' || Array.isArray(param)) {
     const arr = typeof param === 'string' ? [param] : param;
-    return { version: A365_MESSAGE_SCHEMA_VERSION, messages: toOutputMessages(arr) };
+    return { messages: toOutputMessages(arr) };
   }
   return param;
 }
 
 /**
- * Serializes a versioned message wrapper to JSON.
+ * Serializes a message wrapper to JSON.
  *
- * The output is the full wrapper object: `{"version":"0.1.0","messages":[...]}`.
+ * The output is a plain JSON array per OTel gen-ai semantic conventions: `[{...}, ...]`.
  *
  * The try/catch ensures telemetry recording is non-throwing even when
  * message parts contain non-JSON-serializable values (e.g. BigInt, circular refs).
  */
 export function serializeMessages(wrapper: InputMessages | OutputMessages): string {
   try {
-    return JSON.stringify(wrapper);
+    return JSON.stringify(wrapper.messages);
   } catch {
-    return JSON.stringify({
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: [
-        {
-          role: MessageRole.SYSTEM,
-          parts: [
-            {
-              type: 'text',
-              content: `[serialization failed: ${wrapper.messages.length} ${wrapper.messages.length === 1 ? 'message' : 'messages'}]`
-            }
-          ]
-        }
-      ]
-    });
+    return JSON.stringify([
+      {
+        role: MessageRole.SYSTEM,
+        parts: [
+          {
+            type: 'text',
+            content: `[serialization failed: ${wrapper.messages.length} ${wrapper.messages.length === 1 ? 'message' : 'messages'}]`
+          }
+        ],
+        finish_reason: 'error'
+      }
+    ]);
   }
 }

--- a/packages/agents-a365-observability/src/tracing/scopes/OutputScope.ts
+++ b/packages/agents-a365-observability/src/tracing/scopes/OutputScope.ts
@@ -3,7 +3,7 @@
 
 import { SpanKind } from '@opentelemetry/api';
 import { OpenTelemetryScope } from './OpenTelemetryScope';
-import { AgentDetails, UserDetails, OutputResponse, Request, SpanDetails, ResponseMessagesParam, A365_MESSAGE_SCHEMA_VERSION } from '../contracts';
+import { AgentDetails, UserDetails, OutputResponse, OutputMessages, Request, SpanDetails, ResponseMessagesParam } from '../contracts';
 import { OpenTelemetryConstants } from '../constants';
 import { normalizeOutputMessages, serializeMessages } from '../message-utils';
 
@@ -94,10 +94,9 @@ export class OutputScope extends OpenTelemetryScope {
       return;
     }
     const normalized = normalizeOutputMessages(messages);
-    const wrapper = { version: A365_MESSAGE_SCHEMA_VERSION, messages: normalized.messages };
     this.setTagMaybe(
       OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-      serializeMessages(wrapper)
+      serializeMessages(normalized)
     );
   }
 
@@ -107,6 +106,6 @@ export class OutputScope extends OpenTelemetryScope {
   private _isRawDict(messages: ResponseMessagesParam): messages is Record<string, unknown> {
     return typeof messages === 'object' && messages !== null
       && !Array.isArray(messages)
-      && !('version' in messages && 'messages' in messages);
+      && !('messages' in messages && Array.isArray((messages as OutputMessages).messages));
   }
 }

--- a/tests/observability/core/agent365-exporter.test.ts
+++ b/tests/observability/core/agent365-exporter.test.ts
@@ -489,79 +489,67 @@ describe('Agent365Exporter', () => {
 
     it('should shrink blob content in message attributes with sentinel', async () => {
       const largeBlobContent = 'x'.repeat(MAX_SPAN_SIZE_BYTES); // >50KB blob, span will exceed limit
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: [
-            { type: 'blob', modality: 'image', mime_type: 'image/png', content: largeBlobContent },
-            { type: 'text', content: 'Keep this text' },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: [
+          { type: 'blob', modality: 'image', mime_type: 'image/png', content: largeBlobContent },
+          { type: 'text', content: 'Keep this text' },
+        ]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
         'small_attr': 'keep me',
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages[0].parts[0].content).toBe('[blob truncated]');
-      expect(parsed.messages[0].parts[1].content).toBe('Keep this text');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[0].content).toBe('[blob truncated]');
+      expect(parsed[0].parts[1].content).toBe('Keep this text');
       expect(exportedSpan.attributes['small_attr']).toBe('keep me');
     });
 
     it('should shrink tool_call arguments with sentinel in message attributes', async () => {
       const largeArgs = { data: 'x'.repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'assistant',
-          parts: [
-            { type: 'tool_call', name: 'search', id: 'call_1', arguments: largeArgs },
-            { type: 'text', content: 'short text' },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'assistant',
+        parts: [
+          { type: 'tool_call', name: 'search', id: 'call_1', arguments: largeArgs },
+          { type: 'text', content: 'short text' },
+        ]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.messages[0].parts[0].arguments).toBe('[truncated]');
-      expect(parsed.messages[0].parts[0].name).toBe('search');
-      expect(parsed.messages[0].parts[1].content).toBe('short text');
+      expect(parsed[0].parts[0].arguments).toBe('[truncated]');
+      expect(parsed[0].parts[0].name).toBe('search');
+      expect(parsed[0].parts[1].content).toBe('short text');
     });
 
     it('should trim text content in message attributes when oversized', async () => {
       const largeText = 'y'.repeat(MAX_SPAN_SIZE_BYTES);
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: [{ type: 'text', content: largeText }]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: [{ type: 'text', content: largeText }]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.messages[0].parts[0].content).toContain('… [truncated]');
-      expect(parsed.messages[0].parts[0].content.length).toBeLessThan(largeText.length);
+      expect(parsed[0].parts[0].content).toContain('… [truncated]');
+      expect(parsed[0].parts[0].content.length).toBeLessThan(largeText.length);
       const spanSize = Buffer.byteLength(JSON.stringify(exportedSpan), 'utf8');
       expect(spanSize).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
     });
 
     it('should trim utf8 text content without splitting code points', () => {
       const largeEmojiText = '🙂'.repeat(90 * 1024);
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: [{ type: 'text', content: largeEmojiText }]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: [{ type: 'text', content: largeEmojiText }]
+      }]);
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -579,7 +567,7 @@ describe('Agent365Exporter', () => {
 
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
-      const trimmedContent = parsed.messages[0].parts[0].content as string;
+      const trimmedContent = parsed[0].parts[0].content as string;
       expect(trimmedContent).toContain('… [truncated]');
 
       const prefix = trimmedContent.slice(0, -'… [truncated]'.length);
@@ -627,68 +615,59 @@ describe('Agent365Exporter', () => {
 
     it('should shrink tool_call_response response with sentinel in message attributes', async () => {
       const largeResponse = { data: 'x'.repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'tool',
-          parts: [
-            { type: 'tool_call_response', id: 'call_1', response: largeResponse },
-            { type: 'text', content: 'short text' },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'tool',
+        parts: [
+          { type: 'tool_call_response', id: 'call_1', response: largeResponse },
+          { type: 'text', content: 'short text' },
+        ]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.messages[0].parts[0].response).toBe('[truncated]');
-      expect(parsed.messages[0].parts[0].id).toBe('call_1');
-      expect(parsed.messages[0].parts[1].content).toBe('short text');
+      expect(parsed[0].parts[0].response).toBe('[truncated]');
+      expect(parsed[0].parts[0].id).toBe('call_1');
+      expect(parsed[0].parts[1].content).toBe('short text');
     });
 
     it('should shrink server_tool_call payload with sentinel in message attributes', async () => {
       const largePayload = { type: 'web_search', query: 'x'.repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'assistant',
-          parts: [
-            { type: 'server_tool_call', name: 'web_search', id: 'stc_1', server_tool_call: largePayload },
-            { type: 'text', content: 'keep me' },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'assistant',
+        parts: [
+          { type: 'server_tool_call', name: 'web_search', id: 'stc_1', server_tool_call: largePayload },
+          { type: 'text', content: 'keep me' },
+        ]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.messages[0].parts[0].server_tool_call).toBe('[truncated]');
-      expect(parsed.messages[0].parts[0].name).toBe('web_search');
-      expect(parsed.messages[0].parts[1].content).toBe('keep me');
+      expect(parsed[0].parts[0].server_tool_call).toBe('[truncated]');
+      expect(parsed[0].parts[0].name).toBe('web_search');
+      expect(parsed[0].parts[1].content).toBe('keep me');
     });
 
     it('should shrink server_tool_call_response payload with sentinel in message attributes', async () => {
       const largePayload = { type: 'web_search_result', results: 'x'.repeat(MAX_SPAN_SIZE_BYTES) };
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'tool',
-          parts: [
-            { type: 'server_tool_call_response', id: 'stc_1', server_tool_call_response: largePayload },
-            { type: 'text', content: 'keep me' },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'tool',
+        parts: [
+          { type: 'server_tool_call_response', id: 'stc_1', server_tool_call_response: largePayload },
+          { type: 'text', content: 'keep me' },
+        ]
+      }]);
       const { exportedSpan } = await exportAndGetAttributes({
         'gen_ai.input.messages': messageWrapper,
       });
 
       const parsed = JSON.parse(exportedSpan.attributes['gen_ai.input.messages'] as string);
-      expect(parsed.messages[0].parts[0].server_tool_call_response).toBe('[truncated]');
-      expect(parsed.messages[0].parts[0].id).toBe('stc_1');
-      expect(parsed.messages[0].parts[1].content).toBe('keep me');
+      expect(parsed[0].parts[0].server_tool_call_response).toBe('[truncated]');
+      expect(parsed[0].parts[0].id).toBe('stc_1');
+      expect(parsed[0].parts[1].content).toBe('keep me');
     });
 
     it('should shrink blobs alongside other fields by size priority', () => {
@@ -702,10 +681,9 @@ describe('Agent365Exporter', () => {
       }));
       // Add a text part — blobs are larger so they should be shrunk first
       const textPart = { type: 'text' as const, content: 'y'.repeat(1024) };
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{ role: 'user', parts: [...blobParts, textPart] }],
-      });
+      const messageWrapper = JSON.stringify(
+        [{ role: 'user', parts: [...blobParts, textPart] }],
+      );
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -725,7 +703,7 @@ describe('Agent365Exporter', () => {
       expect(resultSize).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
 
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
-      const sentinelCount = parsed.messages[0].parts
+      const sentinelCount = parsed[0].parts
         .filter((p: Record<string, unknown>) => p.type === 'blob' && p.content === '[blob truncated]')
         .length;
       expect(sentinelCount).toBeGreaterThan(0);
@@ -739,13 +717,10 @@ describe('Agent365Exporter', () => {
         { type: 'text', content: 'c'.repeat(100 * 1024) },
         { type: 'reasoning', content: 'd'.repeat(100 * 1024) },
       ];
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: regularParts,
-        }],
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: regularParts,
+      }]);
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -765,7 +740,7 @@ describe('Agent365Exporter', () => {
       expect(resultSize).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
 
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
-      const truncatedCount = parsed.messages[0].parts
+      const truncatedCount = parsed[0].parts
         .filter((part: Record<string, unknown>) => typeof part.content === 'string' && (part.content as string).includes('… [truncated]'))
         .length;
       expect(truncatedCount).toBeGreaterThan(1);
@@ -806,13 +781,10 @@ describe('Agent365Exporter', () => {
       // After trimming, most of the content should be preserved.
 
       const textSize = MAX_SPAN_SIZE_BYTES + 5000; // only ~5KB over
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: [{ type: 'text', content: 'x'.repeat(textSize) }]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: [{ type: 'text', content: 'x'.repeat(textSize) }]
+      }]);
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -829,7 +801,7 @@ describe('Agent365Exporter', () => {
 
       const result = truncateSpan(span);
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
-      const trimmedContent = parsed.messages[0].parts[0].content as string;
+      const trimmedContent = parsed[0].parts[0].content as string;
 
       expect(trimmedContent).toContain('… [truncated]');
       // The trimmed content should retain most of the original — at least 90%
@@ -843,16 +815,13 @@ describe('Agent365Exporter', () => {
       // Only the largest should be trimmed; the medium one should be preserved intact.
       const largeContent = 'L'.repeat(300 * 1024);
       const mediumContent = 'M'.repeat(50 * 1024);
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'user',
-          parts: [
-            { type: 'text', content: largeContent },
-            { type: 'text', content: mediumContent },
-          ]
-        }]
-      });
+      const messageWrapper = JSON.stringify([{
+        role: 'user',
+        parts: [
+          { type: 'text', content: largeContent },
+          { type: 'text', content: mediumContent },
+        ]
+      }]);
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -871,9 +840,9 @@ describe('Agent365Exporter', () => {
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
 
       // The large field was trimmed
-      expect((parsed.messages[0].parts[0].content as string)).toContain('… [truncated]');
+      expect((parsed[0].parts[0].content as string)).toContain('… [truncated]');
       // The medium field should be fully preserved
-      expect(parsed.messages[0].parts[1].content).toBe(mediumContent);
+      expect(parsed[0].parts[1].content).toBe(mediumContent);
       expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
     });
 
@@ -915,10 +884,9 @@ describe('Agent365Exporter', () => {
         mime_type: 'image/png',
         content: 'x'.repeat(blobSize),
       }));
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{ role: 'user', parts: blobParts }],
-      });
+      const messageWrapper = JSON.stringify(
+        [{ role: 'user', parts: blobParts }],
+      );
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -938,9 +906,9 @@ describe('Agent365Exporter', () => {
       expect(resultSize).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
 
       const parsed = JSON.parse(result.attributes!['gen_ai.input.messages'] as string);
-      const sentinelCount = parsed.messages[0].parts
+      const sentinelCount = parsed[0].parts
         .filter((p: Record<string, unknown>) => p.content === '[blob truncated]').length;
-      const preservedCount = parsed.messages[0].parts
+      const preservedCount = parsed[0].parts
         .filter((p: Record<string, unknown>) => p.content !== '[blob truncated]').length;
       // Some blobs should be preserved — not all replaced
       expect(sentinelCount).toBeGreaterThan(0);
@@ -951,14 +919,11 @@ describe('Agent365Exporter', () => {
       // Make the span exceed the limit with non-shrinkable arrays, plus a message attribute
       // that phase 1 cannot shrink enough. Phase 2 should replace it with the overflow sentinel.
       const hugeArray = new Array(100000).fill(42);
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [
-          { role: 'user', parts: [{ type: 'text', content: 'hello user' }] },
-          { role: 'assistant', parts: [{ type: 'text', content: 'hello back' }] },
-          { role: 'user', parts: [{ type: 'text', content: 'another msg' }] },
-        ],
-      });
+      const messageWrapper = JSON.stringify([
+        { role: 'user', parts: [{ type: 'text', content: 'hello user' }] },
+        { role: 'assistant', parts: [{ type: 'text', content: 'hello back' }] },
+        { role: 'user', parts: [{ type: 'text', content: 'another msg' }] },
+      ]);
 
       const span = {
         traceId: '00000000000000000000000000000001',
@@ -978,11 +943,11 @@ describe('Agent365Exporter', () => {
       // The message attribute should be replaced with the overflow sentinel
       const sentinelValue = result.attributes!['gen_ai.input.messages'] as string;
       const parsed = JSON.parse(sentinelValue);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('system');
-      expect(parsed.messages[0].parts[0].type).toBe('text');
-      expect(parsed.messages[0].parts[0].content).toBe('[truncated: 3 messages exceeded limit]');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('system');
+      expect(parsed[0].parts[0].type).toBe('text');
+      expect(parsed[0].parts[0].content).toBe('[truncated: 3 messages exceeded limit]');
     });
 
     it('should replace oversized raw dict in gen_ai.output.messages with overlimit sentinel', () => {
@@ -999,7 +964,7 @@ describe('Agent365Exporter', () => {
       expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
     });
 
-    it('should replace oversized dict with messages array but no version with overlimit sentinel', () => {
+    it('should replace oversized dict (not an array) with overlimit sentinel', () => {
       const dictWithMessages = JSON.stringify({ messages: ['y'.repeat(200 * 1024)], type: 'tool_result' });
       const span = makeSpan({
         'gen_ai.output.messages': dictWithMessages,
@@ -1007,7 +972,7 @@ describe('Agent365Exporter', () => {
       });
 
       const result = truncateSpan(span);
-      // Has messages array but no version string — must NOT be treated as versioned wrapper
+      // Object (not an array) should NOT be treated as message array format
       expect(result.attributes!['gen_ai.output.messages']).toBe('[overlimit]');
       expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
     });
@@ -1024,14 +989,11 @@ describe('Agent365Exporter', () => {
       expect(result.attributes!['gen_ai.output.messages']).toBe(smallDict);
     });
 
-    it('should still use message-aware shrinking for versioned wrapper in gen_ai.output.messages', () => {
-      const messageWrapper = JSON.stringify({
-        version: '0.1.0',
-        messages: [{
-          role: 'assistant',
-          parts: [{ type: 'text', content: 'z'.repeat(200 * 1024) }],
-        }],
-      });
+    it('should still use message-aware shrinking for array wrapper in gen_ai.output.messages', () => {
+      const messageWrapper = JSON.stringify([{
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'z'.repeat(200 * 1024) }],
+      }]);
       const span = makeSpan({
         'gen_ai.output.messages': messageWrapper,
         'other_large': 'a'.repeat(100 * 1024),
@@ -1039,13 +1001,13 @@ describe('Agent365Exporter', () => {
 
       const result = truncateSpan(span);
       const output = result.attributes!['gen_ai.output.messages'] as string;
-      // Versioned wrapper should get message-aware shrinking (trimmed text), not sentinel
+      // Array wrapper should get message-aware shrinking (trimmed text), not sentinel
       expect(output).not.toBe('[overlimit]');
       const parsed = JSON.parse(output);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages[0].parts[0].type).toBe('text');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[0].type).toBe('text');
       // Text content should be trimmed (shorter than original)
-      expect(parsed.messages[0].parts[0].content.length).toBeLessThan(200 * 1024);
+      expect(parsed[0].parts[0].content.length).toBeLessThan(200 * 1024);
       expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThanOrEqual(MAX_SPAN_SIZE_BYTES);
     });
   });

--- a/tests/observability/core/output-scope.test.ts
+++ b/tests/observability/core/output-scope.test.ts
@@ -16,7 +16,6 @@ import {
   OutputMessages,
   MessageRole,
   FinishReason,
-  A365_MESSAGE_SCHEMA_VERSION,
 } from '@microsoft/agents-a365-observability';
 
 describe('OutputScope', () => {
@@ -96,10 +95,10 @@ describe('OutputScope', () => {
     expect(attributes[OpenTelemetryConstants.CHANNEL_NAME_KEY]).toBe('Email');
     expect(attributes[OpenTelemetryConstants.CHANNEL_LINK_KEY]).toBe('https://email.link');
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages).toEqual([
-      { role: 'assistant', parts: [{ type: 'text', content: 'First message' }] },
-      { role: 'assistant', parts: [{ type: 'text', content: 'Second message' }] },
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual([
+      { role: 'assistant', parts: [{ type: 'text', content: 'First message' }], finish_reason: 'stop' },
+      { role: 'assistant', parts: [{ type: 'text', content: 'Second message' }], finish_reason: 'stop' },
     ]);
     // Separate version attribute should not be set
     expect(attributes[OpenTelemetryConstants.A365_MESSAGES_SCHEMA_VERSION_KEY]).toBeUndefined();
@@ -117,11 +116,11 @@ describe('OutputScope', () => {
     const { attributes } = getLastSpan();
 
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
+    expect(Array.isArray(parsed)).toBe(true);
     // Only the last recordOutputMessages call should be present (overwrite semantics)
-    expect(parsed.messages).toEqual([
-      { role: 'assistant', parts: [{ type: 'text', content: 'Overwritten 2' }] },
-      { role: 'assistant', parts: [{ type: 'text', content: 'Overwritten 3' }] },
+    expect(parsed).toEqual([
+      { role: 'assistant', parts: [{ type: 'text', content: 'Overwritten 2' }], finish_reason: 'stop' },
+      { role: 'assistant', parts: [{ type: 'text', content: 'Overwritten 3' }], finish_reason: 'stop' },
     ]);
   });
 
@@ -147,7 +146,6 @@ describe('OutputScope', () => {
 
   it('should accept structured OutputMessages wrapper without re-wrapping', async () => {
     const structured: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Hello structured' }], finish_reason: FinishReason.STOP },
         { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Second structured' }] },
@@ -161,20 +159,18 @@ describe('OutputScope', () => {
     await flushProvider.forceFlush();
     const { attributes } = getLastSpan();
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
+    expect(Array.isArray(parsed)).toBe(true);
     // Should pass through as-is, preserving finish_reason and not double-wrapping
-    expect(parsed.messages).toEqual(structured.messages);
+    expect(parsed).toEqual(structured.messages);
   });
 
   it('should accept structured OutputMessages wrapper in recordOutputMessages (overwrite)', async () => {
     const initial: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Initial structured' }] },
       ],
     };
     const overwrite: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Overwritten structured' }], finish_reason: FinishReason.STOP },
       ],
@@ -187,14 +183,13 @@ describe('OutputScope', () => {
     await flushProvider.forceFlush();
     const { attributes } = getLastSpan();
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
+    expect(Array.isArray(parsed)).toBe(true);
     // Overwrite: only the last call's messages should be present
-    expect(parsed.messages).toEqual(overwrite.messages);
+    expect(parsed).toEqual(overwrite.messages);
   });
 
   it('should overwrite structured OutputMessages with plain string[]', async () => {
     const initial: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Structured initial' }], finish_reason: FinishReason.STOP },
       ],
@@ -207,10 +202,10 @@ describe('OutputScope', () => {
     await flushProvider.forceFlush();
     const { attributes } = getLastSpan();
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
+    expect(Array.isArray(parsed)).toBe(true);
     // Overwrite: only the plain string call should be present
-    expect(parsed.messages).toHaveLength(1);
-    expect(parsed.messages[0]).toEqual({ role: 'assistant', parts: [{ type: 'text', content: 'Plain string overwrite' }] });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({ role: 'assistant', parts: [{ type: 'text', content: 'Plain string overwrite' }], finish_reason: 'stop' });
   });
 
   it('should serialize raw dict (tool call result) directly via constructor', async () => {
@@ -242,9 +237,11 @@ describe('OutputScope', () => {
     await flushProvider.forceFlush();
     const { attributes } = getLastSpan();
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.messages).toHaveLength(1);
-    expect(parsed.messages[0].role).toBe('assistant');
-    expect(parsed.messages[0].parts[0].content).toBe('single output');
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].role).toBe('assistant');
+    expect(parsed[0].parts[0].content).toBe('single output');
+    expect(parsed[0].finish_reason).toBe('stop');
   });
 
   it('should accept a single string in recordOutputMessages', async () => {
@@ -255,7 +252,9 @@ describe('OutputScope', () => {
     await flushProvider.forceFlush();
     const { attributes } = getLastSpan();
     const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-    expect(parsed.messages).toHaveLength(1);
-    expect(parsed.messages[0].parts[0].content).toBe('overwritten single');
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].parts[0].content).toBe('overwritten single');
+    expect(parsed[0].finish_reason).toBe('stop');
   });
 });

--- a/tests/observability/core/scope-messages.test.ts
+++ b/tests/observability/core/scope-messages.test.ts
@@ -20,7 +20,6 @@ import {
   Modality,
   InputMessages,
   OutputMessages,
-  A365_MESSAGE_SCHEMA_VERSION,
 } from '@microsoft/agents-a365-observability';
 import {
   serializeMessages,
@@ -90,7 +89,7 @@ describe('Scope message recording', () => {
   // InvokeAgentScope overrides are trivial super calls sharing the same path)
   // ---------------------------------------------------------------------------
   describe('recordInputMessages / recordOutputMessages', () => {
-    it('should convert string[] input to versioned wrapper with OTEL ChatMessage format', async () => {
+    it('should convert string[] input to plain array with OTEL ChatMessage format', async () => {
       const scope = InferenceScope.start(testRequest, testInferenceDetails, testAgentDetails);
       scope.recordInputMessages(['What is the weather?', 'And traffic?']);
       scope.dispose();
@@ -99,8 +98,8 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages).toEqual([
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toEqual([
         { role: 'user', parts: [{ type: 'text', content: 'What is the weather?' }] },
         { role: 'user', parts: [{ type: 'text', content: 'And traffic?' }] },
       ]);
@@ -108,7 +107,6 @@ describe('Scope message recording', () => {
 
     it('should pass through InputMessages wrapper without re-wrapping', async () => {
       const structured: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [
           { role: MessageRole.SYSTEM, parts: [{ type: 'text', content: 'You are a helpful assistant.' }] },
           { role: MessageRole.USER, parts: [{ type: 'text', content: 'Hello!' }] },
@@ -123,11 +121,11 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages).toEqual(structured.messages);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toEqual(structured.messages);
     });
 
-    it('should convert string[] output to versioned wrapper with OTEL OutputMessage format', async () => {
+    it('should convert string[] output to plain array with OTEL OutputMessage format', async () => {
       const scope = InferenceScope.start(testRequest, testInferenceDetails, testAgentDetails);
       scope.recordOutputMessages(['The weather is sunny.']);
       scope.dispose();
@@ -136,13 +134,13 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages).toEqual([
-        { role: 'assistant', parts: [{ type: 'text', content: 'The weather is sunny.' }] },
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toEqual([
+        { role: 'assistant', parts: [{ type: 'text', content: 'The weather is sunny.' }], finish_reason: 'stop' },
       ]);
     });
 
-    it('should embed version in the serialized wrapper (no separate version attribute)', async () => {
+    it('should serialize as plain array with no version property or attribute', async () => {
       const scope = InferenceScope.start(testRequest, testInferenceDetails, testAgentDetails);
       scope.recordInputMessages(['Hello']);
       scope.dispose();
@@ -150,14 +148,13 @@ describe('Scope message recording', () => {
       await flushProvider.forceFlush();
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
+      expect(Array.isArray(parsed)).toBe(true);
       // Separate version attribute should no longer be set
       expect(attributes[OpenTelemetryConstants.A365_MESSAGES_SCHEMA_VERSION_KEY]).toBeUndefined();
     });
 
     it('should preserve finish_reason on OutputMessages wrapper', async () => {
       const structured: OutputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [
           { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Done.' }], finish_reason: FinishReason.STOP },
           { role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'Partial...' }], finish_reason: FinishReason.LENGTH },
@@ -172,8 +169,8 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.messages[0].finish_reason).toBe('stop');
-      expect(parsed.messages[1].finish_reason).toBe('length');
+      expect(parsed[0].finish_reason).toBe('stop');
+      expect(parsed[1].finish_reason).toBe('length');
     });
   });
 
@@ -181,7 +178,7 @@ describe('Scope message recording', () => {
   // InvokeAgentScope-specific: recordResponse() delegates to recordOutputMessages
   // ---------------------------------------------------------------------------
   describe('InvokeAgentScope.recordResponse', () => {
-    it('should convert response string to versioned wrapper with OTEL OutputMessage format', async () => {
+    it('should convert response string to plain array with OTEL OutputMessage format', async () => {
       const scope = InvokeAgentScope.start(testRequest, {}, testAgentDetails);
       scope.recordResponse('Test response');
       scope.dispose();
@@ -190,10 +187,10 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('assistant');
-      expect(parsed.messages[0].parts[0].content).toBe('Test response');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('assistant');
+      expect(parsed[0].parts[0].content).toBe('Test response');
     });
   });
 
@@ -201,9 +198,8 @@ describe('Scope message recording', () => {
   // Complex OTEL message part types (serialization round-trips)
   // ---------------------------------------------------------------------------
   describe('Complex message part types', () => {
-    it('should serialize tool call request and response parts in wrapper', async () => {
+    it('should serialize tool call request and response parts as plain array', async () => {
       const messages: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [
           {
             role: MessageRole.ASSISTANT,
@@ -229,16 +225,15 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages[0].parts[1].type).toBe('tool_call');
-      expect(parsed.messages[0].parts[1].arguments).toEqual({ query: 'test' });
-      expect(parsed.messages[1].parts[0].type).toBe('tool_call_response');
-      expect(parsed.messages[1].parts[0].response).toEqual({ results: ['item1'] });
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[1].type).toBe('tool_call');
+      expect(parsed[0].parts[1].arguments).toEqual({ query: 'test' });
+      expect(parsed[1].parts[0].type).toBe('tool_call_response');
+      expect(parsed[1].parts[0].response).toEqual({ results: ['item1'] });
     });
 
-    it('should serialize reasoning parts with finish_reason in wrapper', async () => {
+    it('should serialize reasoning parts with finish_reason as plain array', async () => {
       const messages: OutputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [{
           role: MessageRole.ASSISTANT,
           parts: [
@@ -257,15 +252,14 @@ describe('Scope message recording', () => {
       const { attributes } = getLastSpan();
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages[0].parts[0].type).toBe('reasoning');
-      expect(parsed.messages[0].parts[1].type).toBe('text');
-      expect(parsed.messages[0].finish_reason).toBe('stop');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[0].type).toBe('reasoning');
+      expect(parsed[0].parts[1].type).toBe('text');
+      expect(parsed[0].finish_reason).toBe('stop');
     });
 
     it('should serialize blob, file, and URI parts', () => {
       const wrapper: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [{
           role: MessageRole.USER,
           parts: [
@@ -278,15 +272,14 @@ describe('Scope message recording', () => {
 
       const parsed = JSON.parse(serializeMessages(wrapper));
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages[0].parts[0].modality).toBe('image');
-      expect(parsed.messages[0].parts[1].file_id).toBe('file-123');
-      expect(parsed.messages[0].parts[2].uri).toBe('https://example.com/audio.mp3');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[0].modality).toBe('image');
+      expect(parsed[0].parts[1].file_id).toBe('file-123');
+      expect(parsed[0].parts[2].uri).toBe('https://example.com/audio.mp3');
     });
 
     it('should serialize server tool call and generic parts', () => {
       const wrapper: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
         messages: [
           { role: MessageRole.ASSISTANT, parts: [{ type: 'server_tool_call', name: 'mcp_tool', id: 'stc_1', server_tool_call: { endpoint: '/api' } }] },
           { role: MessageRole.TOOL, parts: [{ type: 'server_tool_call_response', id: 'stc_1', server_tool_call_response: { status: 'ok' } }] },
@@ -296,10 +289,10 @@ describe('Scope message recording', () => {
 
       const parsed = JSON.parse(serializeMessages(wrapper));
 
-      expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-      expect(parsed.messages[0].parts[0].server_tool_call.endpoint).toBe('/api');
-      expect(parsed.messages[1].parts[0].server_tool_call_response.status).toBe('ok');
-      expect(parsed.messages[2].parts[0].type).toBe('custom_annotation');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].parts[0].server_tool_call.endpoint).toBe('/api');
+      expect(parsed[1].parts[0].server_tool_call_response.status).toBe('ok');
+      expect(parsed[2].parts[0].type).toBe('custom_annotation');
     });
   });
 });

--- a/tests/observability/core/scopes.test.ts
+++ b/tests/observability/core/scopes.test.ts
@@ -16,9 +16,7 @@ import {
   UserDetails,
   OpenTelemetryConstants,
   OpenTelemetryScope,
-  InputMessages,
   MessageRole,
-  A365_MESSAGE_SCHEMA_VERSION,
 } from '@microsoft/agents-a365-observability';
 import { safeSerializeToJson } from '@microsoft/agents-a365-observability/src/tracing/util';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor, ReadableSpan } from '@opentelemetry/sdk-trace-base';
@@ -810,10 +808,10 @@ describe('Request content and message serialization (span attributes)', () => {
 
       const attributes = getLastSpan().attributes;
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('user');
-      expect(parsed.messages[0].parts[0]).toEqual({ type: 'text', content: 'Hello agent' });
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('user');
+      expect(parsed[0].parts[0]).toEqual({ type: 'text', content: 'Hello agent' });
     });
 
     it('should record a string array as input message attributes', () => {
@@ -822,14 +820,14 @@ describe('Request content and message serialization (span attributes)', () => {
 
       const attributes = getLastSpan().attributes;
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
-      expect(parsed.messages).toHaveLength(2);
-      expect(parsed.messages[0].parts[0].content).toBe('msg1');
-      expect(parsed.messages[1].parts[0].content).toBe('msg2');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].parts[0].content).toBe('msg1');
+      expect(parsed[1].parts[0].content).toBe('msg2');
     });
 
     it('should record a structured InputMessages wrapper as-is', () => {
-      const wrapper: InputMessages = {
-        version: A365_MESSAGE_SCHEMA_VERSION,
+      const wrapper = {
         messages: [{ role: MessageRole.SYSTEM, parts: [{ type: 'text', content: 'system prompt' }] }],
       };
       const scope = InvokeAgentScope.start({ ...testRequest, content: wrapper }, {}, testAgentDetails);
@@ -837,9 +835,9 @@ describe('Request content and message serialization (span attributes)', () => {
 
       const attributes = getLastSpan().attributes;
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('system');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('system');
     });
 
     it('should not set input messages when content is undefined', () => {
@@ -859,9 +857,11 @@ describe('Request content and message serialization (span attributes)', () => {
 
       const attributes = getLastSpan().attributes;
       const parsed = JSON.parse(attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string);
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('assistant');
-      expect(parsed.messages[0].parts[0].content).toBe('single output');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('assistant');
+      expect(parsed[0].parts[0].content).toBe('single output');
+      expect(parsed[0].finish_reason).toBe('stop');
     });
   });
 

--- a/tests/observability/extension/helpers/message-schema-validator.ts
+++ b/tests/observability/extension/helpers/message-schema-validator.ts
@@ -3,12 +3,12 @@
 
 import { expect } from '@jest/globals';
 
-function validateMessageEnvelope(value: unknown): Record<string, unknown> {
-  // Attributes are stored as JSON strings; parse and validate the common envelope.
+function validateMessageArray(value: unknown): Array<Record<string, unknown>> {
+  // Attributes are stored as JSON strings; parse and validate the plain array format.
   expect(typeof value).toBe('string');
   const parsed = JSON.parse(value as string);
-  expect(parsed).toHaveProperty('version', '0.1.0');
-  expect(parsed.messages).toEqual(expect.arrayContaining([expect.anything()]));
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBeGreaterThan(0);
   return parsed;
 }
 
@@ -32,8 +32,8 @@ function validateMessagePart(part: Record<string, unknown>): void {
 
 export function expectValidInputMessages(value: unknown): void {
   // Input messages must have a role and at least one valid part.
-  const parsed = validateMessageEnvelope(value);
-  for (const msg of parsed.messages as Array<Record<string, unknown>>) {
+  const parsed = validateMessageArray(value);
+  for (const msg of parsed) {
     expect(typeof msg.role).toBe('string');
     const parts = msg.parts as Array<Record<string, unknown>>;
     expect(parts.length).toBeGreaterThan(0);
@@ -43,8 +43,8 @@ export function expectValidInputMessages(value: unknown): void {
 
 export function expectValidOutputMessages(value: unknown): void {
   // Output messages follow the same structure, with optional finish_reason.
-  const parsed = validateMessageEnvelope(value);
-  for (const msg of parsed.messages as Array<Record<string, unknown>>) {
+  const parsed = validateMessageArray(value);
+  for (const msg of parsed) {
     expect(typeof msg.role).toBe('string');
     const parts = msg.parts as Array<Record<string, unknown>>;
     expect(parts.length).toBeGreaterThan(0);

--- a/tests/observability/extension/hosting/output-logging-middleware.test.ts
+++ b/tests/observability/extension/hosting/output-logging-middleware.test.ts
@@ -149,7 +149,7 @@ describe('OutputLoggingMiddleware', () => {
 
     expect(outputSpan).toBeDefined();
     expect(outputSpan!.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY]).toBe(
-      JSON.stringify({ version: '0.1.0', messages: [{ role: 'assistant', parts: [{ type: 'text', content: 'Hi there!' }] }] })
+      JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Hi there!' }], finish_reason: 'stop' }])
     );
   });
 
@@ -244,7 +244,7 @@ describe('OutputLoggingMiddleware', () => {
     const outputSpan = exporter.getFinishedSpans().find(s => s.name.includes('output_messages'));
     expect(outputSpan).toBeDefined();
     expect(outputSpan!.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY]).toBe(
-      JSON.stringify({ version: '0.1.0', messages: [{ role: 'assistant', parts: [{ type: 'text', content: 'Async reply' }] }] })
+      JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Async reply' }], finish_reason: 'stop' }])
     );
   });
 

--- a/tests/observability/extension/hosting/scope-utils.test.ts
+++ b/tests/observability/extension/hosting/scope-utils.test.ts
@@ -91,7 +91,7 @@ describe('ScopeUtils.populateFromTurnContext', () => {
         [OpenTelemetryConstants.GEN_AI_AGENT_EMAIL_KEY, 'agent-upn@contoso.com'],
         [OpenTelemetryConstants.GEN_AI_AGENT_DESCRIPTION_KEY, 'assistant'],
         [OpenTelemetryConstants.TENANT_ID_KEY, 'tenant-123'],
-        [OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, JSON.stringify({ version: '0.1.0', messages: [{ role: 'user', parts: [{ type: 'text', content: 'input text' }] }] })]
+        [OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, JSON.stringify([{ role: 'user', parts: [{ type: 'text', content: 'input text' }] }])]
       ])
     );
     scope?.dispose();
@@ -153,7 +153,7 @@ describe('ScopeUtils.populateFromTurnContext', () => {
       [OpenTelemetryConstants.GEN_AI_CALLER_AGENT_APPLICATION_ID_KEY, 'caller-agentBlueprintId'],
       [OpenTelemetryConstants.GEN_AI_CALLER_AGENT_EMAIL_KEY, 'user@contoso.com'],
       [OpenTelemetryConstants.TENANT_ID_KEY, 'tenant-123'],
-      [OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, JSON.stringify({ version: '0.1.0', messages: [{ role: 'user', parts: [{ type: 'text', content: 'invoke message' }] }] })],
+      [OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY, JSON.stringify([{ role: 'user', parts: [{ type: 'text', content: 'invoke message' }] }])],
       [OpenTelemetryConstants.GEN_AI_AGENT_ID_KEY, 'agent-1'],
       [OpenTelemetryConstants.GEN_AI_AGENT_NAME_KEY, 'Agent One'],
       [OpenTelemetryConstants.GEN_AI_AGENT_DESCRIPTION_KEY, 'assistant']

--- a/tests/observability/extension/langchain/LangChainMessageContract.test.ts
+++ b/tests/observability/extension/langchain/LangChainMessageContract.test.ts
@@ -53,19 +53,19 @@ describe("LangChain Message Contract Tests", () => {
       expectValidInputMessages(value);
 
       const parsed = JSON.parse(value);
-      const roles = parsed.messages.map((m: Record<string, unknown>) => m.role);
+      const roles = parsed.map((m: Record<string, unknown>) => m.role);
       expect(roles).toEqual(["system", "user", "assistant", "tool"]);
 
-      expect(parsed.messages[0].parts[0].content).toBe("You are a weather assistant.");
-      expect(parsed.messages[1].parts[0].content).toBe("What's the weather in Seattle?");
+      expect(parsed[0].parts[0].content).toBe("You are a weather assistant.");
+      expect(parsed[1].parts[0].content).toBe("What's the weather in Seattle?");
 
-      const aiParts = parsed.messages[2].parts;
+      const aiParts = parsed[2].parts;
       expect(aiParts.find((p: Record<string, unknown>) => p.type === "text").content).toBe("Let me check.");
       const toolCallPart = aiParts.find((p: Record<string, unknown>) => p.type === "tool_call");
       expect(toolCallPart.name).toBe("get_weather");
       expect(toolCallPart.id).toBe("call_1");
 
-      expect(parsed.messages[3].parts[0].content).toBe("Rainy, 45°F");
+      expect(parsed[3].parts[0].content).toBe("Rainy, 45°F");
     });
   });
 
@@ -81,8 +81,8 @@ describe("LangChain Message Contract Tests", () => {
       expectValidOutputMessages(value);
 
       const parsed = JSON.parse(value);
-      expect(parsed.messages[0].role).toBe("assistant");
-      expect(parsed.messages[0].parts[0].content).toBe("Hello!");
+      expect(parsed[0].role).toBe("assistant");
+      expect(parsed[0].parts[0].content).toBe("Hello!");
     });
 
     it("should map AIMessage with tool_calls in output via generations", () => {
@@ -99,7 +99,7 @@ describe("LangChain Message Contract Tests", () => {
       const value = getOutputAttr();
       expectValidOutputMessages(value);
 
-      const toolPart = JSON.parse(value).messages[0].parts.find((p: Record<string, unknown>) => p.type === "tool_call");
+      const toolPart = JSON.parse(value)[0].parts.find((p: Record<string, unknown>) => p.type === "tool_call");
       expect(toolPart.name).toBe("search");
       expect(toolPart.id).toBe("call_456");
     });

--- a/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
+++ b/tests/observability/extension/langchain/LangChainObservabilityAttributes.test.ts
@@ -48,7 +48,7 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-        JSON.stringify({"version":"0.1.0","messages":[{"role":"user","parts":[{"type":"text","content":"hi"}]}]})
+        JSON.stringify([{"role":"user","parts":[{"type":"text","content":"hi"}]}])
       );
     });
 
@@ -73,7 +73,7 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY,
-        JSON.stringify({"version":"0.1.0","messages":[{"role":"user","parts":[{"type":"text","content":"hello agent"}]}]})
+        JSON.stringify([{"role":"user","parts":[{"type":"text","content":"hello agent"}]}])
       );
     });
 
@@ -98,7 +98,7 @@ describe("LangChain Observability - InvokeAgentScope Attributes", () => {
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY,
-        JSON.stringify({"version":"0.1.0","messages":[{"role":"assistant","parts":[{"type":"text","content":"Hello! How can I assist you today?"}]}]})
+        JSON.stringify([{"role":"assistant","parts":[{"type":"text","content":"Hello! How can I assist you today?"}]}])
       );
     });
 
@@ -515,7 +515,7 @@ describe("LangChain Observability - v1 Format Coverage", () => {
     const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY);
     expectValidInputMessages(value);
     const parsed = JSON.parse(value as string);
-    expect(parsed.messages[0].parts[0].content).toBe("v1 format message");
+    expect(parsed[0].parts[0].content).toBe("v1 format message");
   });
 
   it("should extract output content from v1 AIMessage constructor format", () => {
@@ -538,8 +538,8 @@ describe("LangChain Observability - v1 Format Coverage", () => {
     const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
     expectValidOutputMessages(value);
     const parsed = JSON.parse(value as string);
-    expect(parsed.messages[0].role).toBe("assistant");
-    expect(parsed.messages[0].parts[0].content).toBe("v1 AI response");
+    expect(parsed[0].role).toBe("assistant");
+    expect(parsed[0].parts[0].content).toBe("v1 AI response");
   });
 
   it("should not set input attribute when inputs.messages is missing", () => {
@@ -568,8 +568,8 @@ describe("LangChain Observability - v1 Format Coverage", () => {
 
     const value = getSpanAttribute(mockSpan as any, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
     const parsed = JSON.parse(value as string);
-    expect(parsed.messages).toHaveLength(1);
-    expect(parsed.messages[0].role).toBe("assistant");
-    expect(parsed.messages[0].parts[0].content).toBe("ai response");
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].role).toBe("assistant");
+    expect(parsed[0].parts[0].content).toBe("ai response");
   });
 });

--- a/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
+++ b/tests/observability/extension/openai/OpenAIAgentsTraceProcessor.test.ts
@@ -551,10 +551,10 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('assistant');
-      expect(parsed.messages[0].parts[0]).toEqual({ type: 'text', content: 'Assistant reply' });
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('assistant');
+      expect(parsed[0].parts[0]).toEqual({ type: 'text', content: 'Assistant reply' });
     });
     it('records structured InputMessages for array _input on response spans', async () => {
       const processor = new OpenAIAgentsTraceProcessor(tracer, {});
@@ -586,11 +586,11 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(2);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
       expectValidInputMessages(entry![1]);
-      expect(parsed.messages[0]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 1' }] });
-      expect(parsed.messages[1]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 2' }] });
+      expect(parsed[0]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 1' }] });
+      expect(parsed[1]).toEqual({ role: 'user', parts: [{ type: 'text', content: 'Hello user 2' }] });
     });
 
     it('parses stringified array _input and records all messages in structured format', async () => {
@@ -626,12 +626,12 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(3);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(3);
       expectValidInputMessages(entry![1]);
-      expect(parsed.messages[0].role).toBe('user');
-      expect(parsed.messages[1].role).toBe('user');
-      expect(parsed.messages[2].role).toBe('assistant');
+      expect(parsed[0].role).toBe('user');
+      expect(parsed[1].role).toBe('user');
+      expect(parsed[2].role).toBe('assistant');
     });
 
     it('records structured InputMessages for array input with non standard schema on response spans', async () => {
@@ -664,9 +664,8 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toBeDefined();
-      expect(parsed.messages.length).toBeGreaterThan(0);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(0);
     });
 
     it('records GEN_AI_OUTPUT_MESSAGES in versioned envelope when output is a string', async () => {
@@ -695,7 +694,7 @@ describe('OpenAIAgentsTraceProcessor', () => {
       expect(entry).toBeDefined();
       expectValidOutputMessages(entry![1]);
       const parsed = JSON.parse(entry![1] as string);
-      expect(parsed.messages[0].parts[0].content).toBe('final answer');
+      expect(parsed[0].parts[0].content).toBe('final answer');
     });
 
     it('records structured OutputMessages when output is structured', async () => {
@@ -735,11 +734,11 @@ describe('OpenAIAgentsTraceProcessor', () => {
 
       const value = entry![1] as string;
       const parsed = JSON.parse(value);
-      expect(parsed.version).toBe('0.1.0');
-      expect(parsed.messages).toHaveLength(1);
-      expect(parsed.messages[0].role).toBe('assistant');
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].role).toBe('assistant');
       expectValidOutputMessages(entry![1]);
-      expect(parsed.messages[0].parts).toEqual([
+      expect(parsed[0].parts).toEqual([
         { type: 'text', content: 'Hello user 1' },
         { type: 'text', content: 'Hello user 2' },
       ]);

--- a/tests/observability/extension/openai/OpenAIMessageContract.test.ts
+++ b/tests/observability/extension/openai/OpenAIMessageContract.test.ts
@@ -162,7 +162,7 @@ describe('OpenAI Message Contract Tests', () => {
       const outputValue = getAttrFromArray(attrs, OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY);
       expectValidOutputMessages(outputValue);
 
-      const toolPart = JSON.parse(outputValue as string).messages[0].parts.find((p: any) => p.type === 'tool_call');
+      const toolPart = JSON.parse(outputValue as string)[0].parts.find((p: any) => p.type === 'tool_call');
       expect(toolPart.name).toBe('get_weather');
       expect(toolPart.id).toBe('call_abc');
       expect(toolPart.arguments).toEqual({ city: 'Seattle' });
@@ -172,7 +172,6 @@ describe('OpenAI Message Contract Tests', () => {
   describe('Edge cases', () => {
     it('should return empty messages array for empty input', () => {
       const result = buildStructuredInputMessages([]);
-      expect(result.version).toBe('0.1.0');
       expect(result.messages).toHaveLength(0);
     });
 

--- a/tests/observability/integration/helpers/span-validators.ts
+++ b/tests/observability/integration/helpers/span-validators.ts
@@ -46,7 +46,7 @@ export function validateParentChildRelationship(
 /**
  * Validate A365 message schema on a span's input/output messages.
  * Calls expectValidInputMessages/expectValidOutputMessages from the shared
- * message-schema-validator, which check version "0.1.0", roles, and parts.
+ * message-schema-validator, which check for a plain JSON array of messages with roles and parts.
  */
 export function validateMessageSchema(span: ReadableSpan): void {
   const inputMessages =
@@ -77,17 +77,17 @@ export function validateInputMessageContent(
     span.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string;
   expect(raw).toBeDefined();
   const parsed = JSON.parse(raw);
-  expect(parsed.version).toBe("0.1.0");
-  expect(parsed.messages.length).toBeGreaterThan(0);
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBeGreaterThan(0);
 
   if (expectations.hasRole) {
     expect(
-      parsed.messages.some((m: any) => m.role === expectations.hasRole),
+      parsed.some((m: any) => m.role === expectations.hasRole),
     ).toBe(true);
   }
   if (expectations.hasPartType) {
     expect(
-      parsed.messages.some((m: any) =>
+      parsed.some((m: any) =>
         m.parts?.some((p: any) => p.type === expectations.hasPartType),
       ),
     ).toBe(true);
@@ -112,17 +112,17 @@ export function validateOutputMessageContent(
     span.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string;
   expect(raw).toBeDefined();
   const parsed = JSON.parse(raw);
-  expect(parsed.version).toBe("0.1.0");
-  expect(parsed.messages.length).toBeGreaterThan(0);
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBeGreaterThan(0);
 
   if (expectations.hasRole) {
     expect(
-      parsed.messages.some((m: any) => m.role === expectations.hasRole),
+      parsed.some((m: any) => m.role === expectations.hasRole),
     ).toBe(true);
   }
   if (expectations.hasPartType) {
     expect(
-      parsed.messages.some((m: any) =>
+      parsed.some((m: any) =>
         m.parts?.some((p: any) => p.type === expectations.hasPartType),
       ),
     ).toBe(true);

--- a/tests/observability/integration/langchain-agent-instrument.test.ts
+++ b/tests/observability/integration/langchain-agent-instrument.test.ts
@@ -176,9 +176,8 @@ describe("LangChain Trace Processor Integration Tests", () => {
         const parsedInput = JSON.parse(
           chatSpan.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
         );
-        expect(parsedInput.version).toBe("0.1.0");
-        expect(Array.isArray(parsedInput.messages)).toBe(true);
-        const userMsg = parsedInput.messages.find((m: any) => m.role === "user");
+        expect(Array.isArray(parsedInput)).toBe(true);
+        const userMsg = parsedInput.find((m: any) => m.role === "user");
         expect(userMsg).toBeDefined();
         expect(Array.isArray(userMsg.parts)).toBe(true);
         expect(userMsg.parts[0].type).toBe("text");
@@ -188,8 +187,8 @@ describe("LangChain Trace Processor Integration Tests", () => {
         const parsedOutput = JSON.parse(
           chatSpan.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
         );
-        expect(parsedOutput.version).toBe("0.1.0");
-        const assistantMsg = parsedOutput.messages.find((m: any) => m.role === "assistant");
+        expect(Array.isArray(parsedOutput)).toBe(true);
+        const assistantMsg = parsedOutput.find((m: any) => m.role === "assistant");
         expect(assistantMsg).toBeDefined();
         expect(Array.isArray(assistantMsg.parts)).toBe(true);
         expect(assistantMsg.parts[0].type).toBe("text");

--- a/tests/observability/integration/openai-agent-instrument.test.ts
+++ b/tests/observability/integration/openai-agent-instrument.test.ts
@@ -192,9 +192,8 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         const parsedInput = JSON.parse(
           inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_INPUT_MESSAGES_KEY] as string,
         );
-        expect(parsedInput.version).toBe("0.1.0");
-        expect(Array.isArray(parsedInput.messages)).toBe(true);
-        const userMsg = parsedInput.messages.find((m: any) => m.role === "user");
+        expect(Array.isArray(parsedInput)).toBe(true);
+        const userMsg = parsedInput.find((m: any) => m.role === "user");
         expect(userMsg).toBeDefined();
         expect(Array.isArray(userMsg.parts)).toBe(true);
         expect(userMsg.parts[0].type).toBe("text");
@@ -204,8 +203,8 @@ describe("OpenAI Trace Processor Integration Tests", () => {
         const parsedOutput = JSON.parse(
           inferenceSpan.attributes[OpenTelemetryConstants.GEN_AI_OUTPUT_MESSAGES_KEY] as string,
         );
-        expect(parsedOutput.version).toBe("0.1.0");
-        const assistantMsg = parsedOutput.messages.find((m: any) => m.role === "assistant");
+        expect(Array.isArray(parsedOutput)).toBe(true);
+        const assistantMsg = parsedOutput.find((m: any) => m.role === "assistant");
         expect(assistantMsg).toBeDefined();
         expect(Array.isArray(assistantMsg.parts)).toBe(true);
         expect(assistantMsg.parts[0].type).toBe("text");

--- a/tests/observability/integration/openai-agent-instrument.test.ts
+++ b/tests/observability/integration/openai-agent-instrument.test.ts
@@ -611,19 +611,25 @@ describe("OpenAI Trace Processor Integration Tests", () => {
       // run may surface the tool failure; spans should still be emitted
     }
 
-    await waitForSpans(spans, 2);
+    // Wait for the tool span to appear — the agent may produce multiple spans
+    // and the tool span may arrive after the inference span
+    const startTime = Date.now();
+    const timeout = 15000;
+    let toolSpan: ReadableSpan | undefined;
+    while (!toolSpan && Date.now() - startTime < timeout) {
+      toolSpan = spans.find((s) => s.name === "execute_tool will_throw");
+      if (!toolSpan) await new Promise((resolve) => setTimeout(resolve, 200));
+    }
 
-    // The failing tool should produce an execute_tool span with ERROR status + error.type attribute
-    const errorSpan = spans.find(
-      (s) => s.name === "execute_tool will_throw" && s.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY],
-    );
-    expect(errorSpan).toBeDefined();
-    const errorTypeValue = errorSpan?.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY];
+    expect(toolSpan).toBeDefined();
+    const errorSpan = toolSpan!;
+    expect(errorSpan.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY]).toBeDefined();
+    const errorTypeValue = errorSpan.attributes[OpenTelemetryConstants.ERROR_TYPE_KEY];
     expect(typeof errorTypeValue).toBe("string");
     expect((errorTypeValue as string).length).toBeGreaterThan(0);
     // The Agents SDK wraps tool failures — status code is ERROR, message describes tool failure
-    expect(errorSpan?.status.code).toBe(2); // SpanStatusCode.ERROR
-    expect(errorSpan?.status.message).toContain("tool");
-    console.log(`✅ error.type validated: type="${errorTypeValue}", message="${errorSpan?.status.message}"`);
+    expect(errorSpan.status.code).toBe(2); // SpanStatusCode.ERROR
+    expect(errorSpan.status.message).toContain("tool");
+    console.log(`✅ error.type validated: type="${errorTypeValue}", message="${errorSpan.status.message}"`);
   });
 });

--- a/tests/observability/tracing/message-utils.test.ts
+++ b/tests/observability/tracing/message-utils.test.ts
@@ -7,7 +7,7 @@ import {
   OutputMessage,
   InputMessages,
   OutputMessages,
-  A365_MESSAGE_SCHEMA_VERSION,
+  DEFAULT_FINISH_REASON,
 } from '@microsoft/agents-a365-observability';
 import {
   isWrappedMessages,
@@ -21,7 +21,6 @@ import {
 describe('isWrappedMessages', () => {
   it('returns true for InputMessages wrapper', () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: 'text', content: 'hi' }] }],
     };
     expect(isWrappedMessages(wrapper)).toBe(true);
@@ -29,7 +28,6 @@ describe('isWrappedMessages', () => {
 
   it('returns true for OutputMessages wrapper', () => {
     const wrapper: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'hello' }] }],
     };
     expect(isWrappedMessages(wrapper)).toBe(true);
@@ -48,15 +46,11 @@ describe('isWrappedMessages', () => {
   });
 
   it('returns false for object missing messages property', () => {
-    expect(isWrappedMessages({ version: '0.1.0' } as unknown as any)).toBe(false);
-  });
-
-  it('returns false for object missing version property', () => {
-    expect(isWrappedMessages({ messages: [] } as unknown as any)).toBe(false);
-  });
-
-  it('returns false for arbitrary non-matching object', () => {
     expect(isWrappedMessages({ foo: 'bar' } as unknown as any)).toBe(false);
+  });
+
+  it('returns false for object with non-array messages property', () => {
+    expect(isWrappedMessages({ messages: 'not-an-array' } as unknown as any)).toBe(false);
   });
 });
 
@@ -81,11 +75,11 @@ describe('toInputMessages', () => {
 });
 
 describe('toOutputMessages', () => {
-  it('wraps strings as OutputMessage with role=assistant and TextPart', () => {
+  it('wraps strings as OutputMessage with role=assistant, TextPart, and default finish_reason', () => {
     const result = toOutputMessages(['response 1', 'response 2']);
     expect(result).toEqual([
-      { role: 'assistant', parts: [{ type: 'text', content: 'response 1' }] },
-      { role: 'assistant', parts: [{ type: 'text', content: 'response 2' }] },
+      { role: 'assistant', parts: [{ type: 'text', content: 'response 1' }], finish_reason: 'stop' },
+      { role: 'assistant', parts: [{ type: 'text', content: 'response 2' }], finish_reason: 'stop' },
     ]);
   });
 
@@ -95,40 +89,50 @@ describe('toOutputMessages', () => {
 });
 
 describe('normalizeInputMessages', () => {
-  it('wraps string[] into versioned InputMessages', () => {
+  it('wraps string[] into InputMessages', () => {
     const result = normalizeInputMessages(['hello']);
     expect(result).toEqual({
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: 'user', parts: [{ type: 'text', content: 'hello' }] }],
     });
   });
 
   it('returns InputMessages wrapper as-is', () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.SYSTEM, parts: [{ type: 'text', content: 'system prompt' }] }],
     };
     expect(normalizeInputMessages(wrapper)).toBe(wrapper);
   });
 
-  it('wraps empty string[] into versioned wrapper with empty messages', () => {
+  it('wraps a single string into InputMessages', () => {
+    const result = normalizeInputMessages('hello');
+    expect(result).toEqual({
+      messages: [{ role: 'user', parts: [{ type: 'text', content: 'hello' }] }],
+    });
+  });
+
+  it('wraps empty string[] into wrapper with empty messages', () => {
     const result = normalizeInputMessages([]);
-    expect(result).toEqual({ version: A365_MESSAGE_SCHEMA_VERSION, messages: [] });
+    expect(result).toEqual({ messages: [] });
   });
 });
 
 describe('normalizeOutputMessages', () => {
-  it('wraps string[] into versioned OutputMessages', () => {
+  it('wraps string[] into OutputMessages with default finish_reason', () => {
     const result = normalizeOutputMessages(['response']);
     expect(result).toEqual({
-      version: A365_MESSAGE_SCHEMA_VERSION,
-      messages: [{ role: 'assistant', parts: [{ type: 'text', content: 'response' }] }],
+      messages: [{ role: 'assistant', parts: [{ type: 'text', content: 'response' }], finish_reason: 'stop' }],
+    });
+  });
+
+  it('wraps a single string into OutputMessages with default finish_reason', () => {
+    const result = normalizeOutputMessages('response');
+    expect(result).toEqual({
+      messages: [{ role: 'assistant', parts: [{ type: 'text', content: 'response' }], finish_reason: 'stop' }],
     });
   });
 
   it('returns OutputMessages wrapper as-is', () => {
     const wrapper: OutputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.ASSISTANT, parts: [{ type: 'text', content: 'done' }], finish_reason: 'stop' }],
     };
     expect(normalizeOutputMessages(wrapper)).toBe(wrapper);
@@ -136,40 +140,37 @@ describe('normalizeOutputMessages', () => {
 });
 
 describe('serializeMessages', () => {
-  it('returns JSON for versioned wrapper', () => {
+  it('returns JSON array for message wrapper', () => {
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: 'text', content: 'hello' }] }],
     };
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages).toEqual(wrapper.messages);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual(wrapper.messages);
   });
 
-  it('serializes empty messages wrapper', () => {
-    const wrapper: InputMessages = { version: A365_MESSAGE_SCHEMA_VERSION, messages: [] };
+  it('serializes empty messages wrapper as empty array', () => {
+    const wrapper: InputMessages = { messages: [] };
     const parsed = JSON.parse(serializeMessages(wrapper));
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages).toEqual([]);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toEqual([]);
   });
 
   it('serializes large messages without truncation', () => {
     const largeContent = 'x'.repeat(100_000);
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: 'text', content: largeContent }] }],
     };
 
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.messages[0].parts[0].content).toBe(largeContent);
+    expect(parsed[0].parts[0].content).toBe(largeContent);
   });
 
   it('does not mutate the original messages', () => {
     const original = 'z'.repeat(50_000);
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [{ role: MessageRole.USER, parts: [{ type: 'text', content: original }] }],
     };
 
@@ -183,7 +184,6 @@ describe('serializeMessages', () => {
     circular.self = circular;
 
     const wrapper: InputMessages = {
-      version: A365_MESSAGE_SCHEMA_VERSION,
       messages: [
         { role: MessageRole.TOOL, parts: [{ type: 'tool_call_response', id: 'tc1', response: circular }] },
       ],
@@ -191,8 +191,8 @@ describe('serializeMessages', () => {
 
     const result = serializeMessages(wrapper);
     const parsed = JSON.parse(result);
-    expect(parsed.version).toBe(A365_MESSAGE_SCHEMA_VERSION);
-    expect(parsed.messages[0].parts[0].content).toContain('serialization failed');
-    expect(parsed.messages[0].parts[0].content).toContain('1 message');
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].parts[0].content).toContain('serialization failed');
+    expect(parsed[0].parts[0].content).toContain('1 message');
   });
 });

--- a/tests/observability/tracing/message-utils.test.ts
+++ b/tests/observability/tracing/message-utils.test.ts
@@ -7,7 +7,6 @@ import {
   OutputMessage,
   InputMessages,
   OutputMessages,
-  DEFAULT_FINISH_REASON,
 } from '@microsoft/agents-a365-observability';
 import {
   isWrappedMessages,


### PR DESCRIPTION
## Summary
- Remove the versioned `{ version: "0.1.0", messages: [...] }` envelope from message serialization — messages now serialize as a plain JSON array `[...]` per OTel gen-ai semantic conventions
- Default `finish_reason` to `"stop"` on output messages created from plain strings via `toOutputMessages`/`normalizeOutputMessages`
- Tighten `isWrappedMessages` type guard with `Array.isArray` check to prevent false positives

Port of microsoft/Agent365-dotnet#253.

## Test plan
- [x] All 1270 unit tests pass
- [x] Build succeeds (CJS + ESM)
- [x] Lint clean
- [ ] Verify integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)