### PR TITLE
Fix fast-uri cve issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "pnpm": {
     "overrides": {
       "@types/uuid": "^9.0.8",
+      "fast-uri": "^3.1.2",
       "hono": "^4.11.7",
       "uuid": "^10.0.0",
       "zod": "^4.1.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,7 @@ catalogs:
 
 overrides:
   '@types/uuid': ^9.0.8
+  fast-uri: ^3.1.2
   hono: ^4.11.7
   uuid: ^10.0.0
   zod: ^4.1.12
@@ -2396,8 +2397,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -5111,7 +5112,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5575,7 +5576,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.3: {}
 
   fb-watchman@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,14 @@ overrides:
   # Zod
   "zod": "^4.1.12"
 
+  # fast-uri - security remediation. Forces a patched release that fixes two URI
+  # normalization issues: percent-encoded authority-delimiter decoding (fixed in
+  # 3.1.2) and percent-encoded path-separator / dot-segment decoding (fixed in
+  # 3.1.1). Pinned within the 3.x line to satisfy ajv@8's "fast-uri: ^3.0.1"
+  # requirement. Remove once the transitive parents (ajv /
+  # @modelcontextprotocol/sdk) resolve a patched fast-uri by default.
+  "fast-uri": "^3.1.2"
+
   # Development dependencies - align versions
   "@types/uuid": "^9.0.0"
   "uuid": "^10.0.0"


### PR DESCRIPTION
# Security: force transitive `fast-uri` to patched `3.1.3`

## Summary

Pins the transitive dependency **`fast-uri` from the vulnerable `3.1.0` to the patched
`3.1.3`** using a pnpm `overrides` entry, remediating two URI-normalization
vulnerabilities. `fast-uri` is not a direct dependency — it is pulled in through:

```text
@modelcontextprotocol/sdk@1.29.0 → ajv@8.20.0 → fast-uri@3.1.0
```

## Motivation

`fast-uri@3.1.0` is affected by two advisories, and the resolved version falls inside the
vulnerable range of **both**:

1. **Authority-delimiter decoding** (`fast-uri <= 3.1.1`, fixed in **3.1.2**) —
   percent-encoded authority delimiters (`%40` → `@`, `%3A` → `:`) are decoded inside the
   host and re-serialized as raw characters, so `http://trusted.com%40evil.com/` normalizes
   to `http://trusted.com@evil.com/` (host becomes `evil.com`). Can defeat host
   allowlist / redirect / SSRF-style checks that normalize before validating.
2. **Path-separator / dot-segment decoding** (`fast-uri <= 3.1.0`, fixed in **3.1.1**) —
   `%2F` and `%2E` are decoded before dot-segment removal in `normalize()` / `equal()`, so
   `http://example.com/public/%2e%2e/admin` collapses to `http://example.com/admin`. Can
   defeat path-based policy checks.

`ajv` uses `fast-uri` to validate the `uri` / `uri-reference` string formats, which is the
exact normalization surface described above.

## What changed

| File | Change |
|------|--------|
| [pnpm-workspace.yaml](../pnpm-workspace.yaml) | Added a documented `fast-uri: "^3.1.2"` entry to the `overrides:` block. |
| [package.json](../package.json) | Added `"fast-uri": "^3.1.2"` to `pnpm.overrides` (the block pnpm actually consumes in this repo — see note below). |
| [pnpm-lock.yaml](../pnpm-lock.yaml) | `fast-uri` `3.1.0 → 3.1.3` (resolution + integrity + both snapshot references) and the override recorded in the lockfile `overrides:` block. |

Net diff for the manifests + lockfile is **14 insertions / 4 deletions** — no unrelated
packages touched.

## Approach & rationale (chosen for maintainability)

- **Why an override (not just a re-resolve):** both transitive parents
  (`@modelcontextprotocol/sdk@1.29.0`, `ajv@8.20.0`) are already at their latest published
  versions, and the latest `ajv` still declares `fast-uri: ^3.0.1`. There is no parent bump
  available, so a version floor is required. The override is a **documented guardrail** that
  prevents any future resolution from sliding back below the patched release. This matches
  the repository's existing convention for the `@isaacs/brace-expansion` override.
- **Why `^3.1.2`:** `3.1.2` is the fix boundary that covers **both** advisories. The caret
  stays inside `ajv@8`'s `fast-uri: ^3.0.1` requirement (so `4.x` is intentionally excluded)
  and currently resolves to the newest in-range patch, **`3.1.3`**.
- **Override placed in both manifests:** the lockfile's `overrides:` block reflects
  `package.json`'s `pnpm.overrides` in this repo (it contains `hono`, which only exists in
  `package.json`, and omits `@isaacs/brace-expansion`, which only exists in
  `pnpm-workspace.yaml`). To guarantee the fix is effective **and** stay consistent with the
  existing dual-declared overrides (`zod`, `uuid`, `@types/uuid` are already in both), the
  entry was added to both files. The `pnpm-workspace.yaml` entry also carries the
  explanatory comment for future maintainers.
- **Lockfile updated surgically (by hand):** a normal `pnpm install` in the build
  environment rewrites every tarball URL/integrity to an internal Azure Artifacts mirror
  (`*.pkgs.visualstudio.com`, sha1), which must not land in this public repo. Only the four
  `fast-uri` entries were changed, preserving the public `registry.npmjs.org` + `sha512`
  format for all other packages. The `3.1.3` `sha512` integrity was verified by hashing the
  package tarball and cross-checking its `sha1` against the registry value.

## Verification

- `fast-uri@3.1.0` no longer appears anywhere in `pnpm-lock.yaml`; it resolves to `3.1.3`.
- Lockfile diff is limited to the four `fast-uri` lines + the override entry (no
  internal-feed URL leakage, no unrelated churn).
- `pnpm install --frozen-lockfile --lockfile-only` → **exit 0** in ~350 ms, i.e. the
  lockfile is consistent with the manifests and CI's frozen install will pass.
- `3.1.3` `sha512` integrity independently reproduced from the tarball bytes
  (`sha1` cross-check matched the registry hash exactly).

Reviewer sanity check:

```bash
grep "fast-uri" pnpm-lock.yaml          # all references show 3.1.3 + override ^3.1.2
pnpm install --frozen-lockfile          # should succeed with no lockfile changes
pnpm audit                              # fast-uri advisories no longer reported
```

## Risk & compatibility

- **Low.** The pin stays within `ajv`'s declared `^3.0.1` range; only patch-level behavior
  of `fast-uri` changes. No API surface change.
- No production source code changes — dependency metadata only.

## Rollback / follow-up

- **Rollback:** revert this PR (restores `fast-uri@3.1.0` in the lockfile and removes the
  override entries).
- **Follow-up:** once `@modelcontextprotocol/sdk` / `ajv` ship releases that already resolve
  a patched `fast-uri`, the override can be removed and the lockfile re-resolved.
- Not suppressed via `auditConfig.ignoreCves` / `ignoreGhsas` — a real patched release
  exists, so upgrading is the correct action.

## Checklist

- [x] Vulnerable version removed from the lockfile
- [x] Override pinned within the parent's compatible range (`^3.0.1`)
- [x] Lockfile consistent with manifests (`--frozen-lockfile` passes)
- [x] No unrelated lockfile churn / no internal-feed URLs introduced
- [x] Integrity hash independently verified
- [ ] `pnpm audit` re-run in CI to confirm the advisories clear
